### PR TITLE
feat(driver-versions): add foil effects, Mesa/GNOME cards, CodeBlock refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /docs/contributing.md
 /static/feeds/*.json
 /static/data/*.json
+!/static/data/sbom-attestations.json
 
 # Misc
 .DS_Store

--- a/scripts/fetch-github-driver-versions.js
+++ b/scripts/fetch-github-driver-versions.js
@@ -156,6 +156,7 @@ function buildRow(item, streamId) {
       hweKernel: extractVersion(content, ["HWE Kernel"]),
       mesa: extractVersion(content, ["Mesa"]),
       nvidia: extractVersion(content, ["Nvidia", "NVIDIA"]),
+      gnome: extractVersion(content, ["Gnome", "GNOME"]),
     },
   };
 }
@@ -175,6 +176,7 @@ function buildRowFromApiRelease(release, streamId) {
       hweKernel: extractVersionFromMarkdown(body, ["HWE Kernel"]),
       mesa: extractVersionFromMarkdown(body, ["Mesa"]),
       nvidia: extractVersionFromMarkdown(body, ["Nvidia", "NVIDIA"]),
+      gnome: extractVersionFromMarkdown(body, ["Gnome", "GNOME"]),
     },
   };
 }

--- a/src/components/DriverVersionsCatalog.module.css
+++ b/src/components/DriverVersionsCatalog.module.css
@@ -245,25 +245,17 @@
 }
 
 .commandBlock :global(.theme-code-block) {
-  display: inline-block;
-  width: auto;
-  max-width: 100%;
+  display: block;
+  width: 100%;
   margin-top: 0.15rem;
   margin-bottom: 0;
-}
-
-.commandBlock :global(button[class*="copyButton"]) {
-  opacity: 1;
-}
-
-.commandBlock :global([class*="buttonGroup"] button) {
-  opacity: 1 !important;
 }
 
 .commandBlock :global(pre) {
   margin: 0;
   white-space: pre-wrap;
   word-break: break-word;
+  /* padding-right handled globally in custom.css */
 }
 
 .archiveTimeline {

--- a/src/components/DriverVersionsCatalog.module.css
+++ b/src/components/DriverVersionsCatalog.module.css
@@ -144,9 +144,42 @@
 }
 
 .majorBump {
-  border-color: color-mix(in srgb, #d97b00 70%, var(--ifm-color-emphasis-300));
-  box-shadow: 0 0 0 2px color-mix(in srgb, #d97b00 28%, transparent);
-  background: color-mix(in srgb, #d97b00 14%, var(--ifm-background-color));
+  position: relative;
+  overflow: hidden;
+  border: 2px solid #e6c200;
+  background: linear-gradient(
+    135deg,
+    rgba(255, 215, 0, 0.15) 0%,
+    rgba(255, 237, 78, 0.22) 50%,
+    rgba(255, 215, 0, 0.15) 100%
+  );
+  box-shadow:
+    0 4px 12px rgba(255, 215, 0, 0.3),
+    inset 0 1px 0 rgba(255, 255, 255, 0.3);
+}
+
+.majorBump::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  mix-blend-mode: color-dodge;
+  z-index: 1;
+  background-image: linear-gradient(
+    115deg,
+    transparent 20%,
+    hsla(45, 100%, 70%, 0.3) 36%,
+    hsla(50, 100%, 65%, 0.5) 43%,
+    hsla(55, 100%, 60%, 0.6) 50%,
+    hsla(50, 100%, 65%, 0.5) 57%,
+    hsla(45, 100%, 70%, 0.3) 64%,
+    transparent 80%
+  );
+  background-size: 300% 300%;
+  background-position: 50% 50%;
+  opacity: 0.35;
+  filter: brightness(1.2) contrast(1.3);
 }
 
 .nvidiaCard {
@@ -167,9 +200,42 @@
 }
 
 .minorBump {
-  border-color: color-mix(in srgb, #9aa4b0 78%, var(--ifm-color-emphasis-300));
-  box-shadow: 0 0 0 2px color-mix(in srgb, #9aa4b0 26%, transparent);
-  background: color-mix(in srgb, #c7ccd3 24%, var(--ifm-background-color));
+  position: relative;
+  overflow: hidden;
+  border: 2px solid #b8c6d8;
+  background: linear-gradient(
+    135deg,
+    rgba(176, 196, 222, 0.15) 0%,
+    rgba(192, 210, 235, 0.22) 50%,
+    rgba(176, 196, 222, 0.15) 100%
+  );
+  box-shadow:
+    0 4px 12px rgba(176, 196, 222, 0.3),
+    inset 0 1px 0 rgba(255, 255, 255, 0.3);
+}
+
+.minorBump::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  mix-blend-mode: color-dodge;
+  z-index: 1;
+  background-image: linear-gradient(
+    115deg,
+    transparent 20%,
+    hsla(215, 40%, 80%, 0.3) 36%,
+    hsla(220, 45%, 75%, 0.5) 43%,
+    hsla(225, 40%, 70%, 0.6) 50%,
+    hsla(220, 45%, 75%, 0.5) 57%,
+    hsla(215, 40%, 80%, 0.3) 64%,
+    transparent 80%
+  );
+  background-size: 300% 300%;
+  background-position: 50% 50%;
+  opacity: 0.35;
+  filter: brightness(1.2) contrast(1.3);
 }
 
 .majorVersionLabel {
@@ -179,6 +245,8 @@
   font-size: 0.72rem;
   color: var(--ifm-color-emphasis-700);
   font-weight: 700;
+  position: relative;
+  z-index: 2;
 }
 
 .majorVersionValue {
@@ -189,6 +257,8 @@
   font-weight: 800;
   color: var(--ifm-color-emphasis-900);
   word-break: break-word;
+  position: relative;
+  z-index: 2;
 }
 
 .versionMissing {
@@ -199,27 +269,33 @@
 .bumpTag {
   display: inline-block;
   margin-top: 0.35rem;
-  border: 1px solid color-mix(in srgb, #d97b00 70%, var(--ifm-color-emphasis-300));
+  border: 1px solid #e6c200;
   border-radius: 999px;
   padding: 0.08rem 0.42rem;
   font-size: 0.7rem;
   font-weight: 700;
   letter-spacing: 0.02em;
   text-transform: uppercase;
+  background: linear-gradient(135deg, rgba(255, 215, 0, 0.25), rgba(255, 237, 78, 0.35));
+  color: #7a5c00;
+  position: relative;
+  z-index: 2;
 }
 
 .minorTag {
   display: inline-block;
   margin-top: 0.35rem;
-  border: 1px solid color-mix(in srgb, #8f99a5 78%, var(--ifm-color-emphasis-300));
+  border: 1px solid #b8c6d8;
   border-radius: 999px;
   padding: 0.08rem 0.42rem;
   font-size: 0.7rem;
   font-weight: 700;
   letter-spacing: 0.02em;
   text-transform: uppercase;
-  color: var(--ifm-color-emphasis-800);
-  background: color-mix(in srgb, #d2d7de 38%, var(--ifm-background-color));
+  background: linear-gradient(135deg, rgba(176, 196, 222, 0.3), rgba(192, 210, 235, 0.4));
+  color: #3a4a5a;
+  position: relative;
+  z-index: 2;
 }
 
 .rebaseInline {

--- a/src/components/DriverVersionsCatalog.module.css
+++ b/src/components/DriverVersionsCatalog.module.css
@@ -396,6 +396,236 @@
   z-index: 2;
 }
 
+.mesaCard {
+  border-color: color-mix(in srgb, #e06020 55%, var(--ifm-color-emphasis-300));
+  background: color-mix(in srgb, #e06020 10%, var(--ifm-background-color));
+}
+
+.mesaMajorBump {
+  position: relative;
+  overflow: hidden;
+  border: 2px solid #c04000;
+  background: linear-gradient(
+    135deg,
+    rgba(224, 96, 32, 0.15) 0%,
+    rgba(255, 128, 48, 0.22) 50%,
+    rgba(224, 96, 32, 0.15) 100%
+  );
+  box-shadow:
+    0 4px 12px rgba(224, 96, 32, 0.3),
+    inset 0 1px 0 rgba(255, 255, 255, 0.3);
+}
+
+.mesaMajorBump::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  mix-blend-mode: color-dodge;
+  z-index: 1;
+  background-image: linear-gradient(
+    115deg,
+    transparent 20%,
+    hsla(20, 100%, 65%, 0.3) 36%,
+    hsla(25, 100%, 60%, 0.5) 43%,
+    hsla(30, 100%, 55%, 0.6) 50%,
+    hsla(25, 100%, 60%, 0.5) 57%,
+    hsla(20, 100%, 65%, 0.3) 64%,
+    transparent 80%
+  );
+  background-size: 300% 300%;
+  background-position: 50% 50%;
+  opacity: 0.35;
+  filter: brightness(1.2) contrast(1.3);
+}
+
+.mesaMinorBump {
+  position: relative;
+  overflow: hidden;
+  border: 2px solid color-mix(in srgb, #e06020 68%, var(--ifm-color-emphasis-300));
+  background: linear-gradient(
+    135deg,
+    rgba(224, 96, 32, 0.10) 0%,
+    rgba(240, 120, 56, 0.16) 50%,
+    rgba(224, 96, 32, 0.10) 100%
+  );
+  box-shadow:
+    0 4px 12px rgba(224, 96, 32, 0.18),
+    inset 0 1px 0 rgba(255, 255, 255, 0.2);
+}
+
+.mesaMinorBump::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  mix-blend-mode: color-dodge;
+  z-index: 1;
+  background-image: linear-gradient(
+    115deg,
+    transparent 20%,
+    hsla(20, 60%, 70%, 0.2) 36%,
+    hsla(25, 65%, 65%, 0.35) 43%,
+    hsla(30, 60%, 60%, 0.4) 50%,
+    hsla(25, 65%, 65%, 0.35) 57%,
+    hsla(20, 60%, 70%, 0.2) 64%,
+    transparent 80%
+  );
+  background-size: 300% 300%;
+  background-position: 50% 50%;
+  opacity: 0.28;
+  filter: brightness(1.1) contrast(1.2);
+}
+
+.mesaBumpTag {
+  display: inline-block;
+  margin-top: 0.35rem;
+  border: 1px solid #a03000;
+  border-radius: 999px;
+  padding: 0.08rem 0.42rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  background: #e06020;
+  color: #fff3ee;
+  position: relative;
+  z-index: 2;
+}
+
+.mesaMinorTag {
+  display: inline-block;
+  margin-top: 0.35rem;
+  border: 1px solid #b04820;
+  border-radius: 999px;
+  padding: 0.08rem 0.42rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  background: #f0c0a0;
+  color: #4a1800;
+  position: relative;
+  z-index: 2;
+}
+
+.gnomeCard {
+  border-color: color-mix(in srgb, #3584e4 55%, var(--ifm-color-emphasis-300));
+  background: color-mix(in srgb, #3584e4 10%, var(--ifm-background-color));
+}
+
+.gnomeMajorBump {
+  position: relative;
+  overflow: hidden;
+  border: 2px solid #1a5ab8;
+  background: linear-gradient(
+    135deg,
+    rgba(53, 132, 228, 0.15) 0%,
+    rgba(78, 160, 255, 0.22) 50%,
+    rgba(53, 132, 228, 0.15) 100%
+  );
+  box-shadow:
+    0 4px 12px rgba(53, 132, 228, 0.3),
+    inset 0 1px 0 rgba(255, 255, 255, 0.3);
+}
+
+.gnomeMajorBump::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  mix-blend-mode: color-dodge;
+  z-index: 1;
+  background-image: linear-gradient(
+    115deg,
+    transparent 20%,
+    hsla(210, 100%, 70%, 0.3) 36%,
+    hsla(215, 100%, 65%, 0.5) 43%,
+    hsla(220, 100%, 60%, 0.6) 50%,
+    hsla(215, 100%, 65%, 0.5) 57%,
+    hsla(210, 100%, 70%, 0.3) 64%,
+    transparent 80%
+  );
+  background-size: 300% 300%;
+  background-position: 50% 50%;
+  opacity: 0.35;
+  filter: brightness(1.2) contrast(1.3);
+}
+
+.gnomeMinorBump {
+  position: relative;
+  overflow: hidden;
+  border: 2px solid color-mix(in srgb, #3584e4 68%, var(--ifm-color-emphasis-300));
+  background: linear-gradient(
+    135deg,
+    rgba(53, 132, 228, 0.10) 0%,
+    rgba(78, 160, 255, 0.16) 50%,
+    rgba(53, 132, 228, 0.10) 100%
+  );
+  box-shadow:
+    0 4px 12px rgba(53, 132, 228, 0.18),
+    inset 0 1px 0 rgba(255, 255, 255, 0.2);
+}
+
+.gnomeMinorBump::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  mix-blend-mode: color-dodge;
+  z-index: 1;
+  background-image: linear-gradient(
+    115deg,
+    transparent 20%,
+    hsla(210, 60%, 75%, 0.2) 36%,
+    hsla(215, 65%, 70%, 0.35) 43%,
+    hsla(220, 60%, 65%, 0.4) 50%,
+    hsla(215, 65%, 70%, 0.35) 57%,
+    hsla(210, 60%, 75%, 0.2) 64%,
+    transparent 80%
+  );
+  background-size: 300% 300%;
+  background-position: 50% 50%;
+  opacity: 0.28;
+  filter: brightness(1.1) contrast(1.2);
+}
+
+.gnomeBumpTag {
+  display: inline-block;
+  margin-top: 0.35rem;
+  border: 1px solid #1040a0;
+  border-radius: 999px;
+  padding: 0.08rem 0.42rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  background: #3584e4;
+  color: #e8f2ff;
+  position: relative;
+  z-index: 2;
+}
+
+.gnomeMinorTag {
+  display: inline-block;
+  margin-top: 0.35rem;
+  border: 1px solid #2060c0;
+  border-radius: 999px;
+  padding: 0.08rem 0.42rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  background: #b0d0f8;
+  color: #001840;
+  position: relative;
+  z-index: 2;
+}
+
 .rebaseInline {
   margin-top: 0.6rem;
   border: 1px solid var(--ifm-color-emphasis-300);

--- a/src/components/DriverVersionsCatalog.module.css
+++ b/src/components/DriverVersionsCatalog.module.css
@@ -188,15 +188,81 @@
 }
 
 .nvidiaMajorBump {
-  border-color: color-mix(in srgb, #76b900 82%, var(--ifm-color-emphasis-300));
-  box-shadow: 0 0 0 2px color-mix(in srgb, #76b900 35%, transparent);
-  background: color-mix(in srgb, #76b900 22%, var(--ifm-background-color));
+  position: relative;
+  overflow: hidden;
+  border: 2px solid #5a9900;
+  background: linear-gradient(
+    135deg,
+    rgba(118, 185, 0, 0.15) 0%,
+    rgba(160, 220, 0, 0.22) 50%,
+    rgba(118, 185, 0, 0.15) 100%
+  );
+  box-shadow:
+    0 4px 12px rgba(118, 185, 0, 0.3),
+    inset 0 1px 0 rgba(255, 255, 255, 0.3);
+}
+
+.nvidiaMajorBump::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  mix-blend-mode: color-dodge;
+  z-index: 1;
+  background-image: linear-gradient(
+    115deg,
+    transparent 20%,
+    hsla(85, 100%, 65%, 0.3) 36%,
+    hsla(90, 100%, 60%, 0.5) 43%,
+    hsla(95, 100%, 55%, 0.6) 50%,
+    hsla(90, 100%, 60%, 0.5) 57%,
+    hsla(85, 100%, 65%, 0.3) 64%,
+    transparent 80%
+  );
+  background-size: 300% 300%;
+  background-position: 50% 50%;
+  opacity: 0.35;
+  filter: brightness(1.2) contrast(1.3);
 }
 
 .nvidiaMinorBump {
-  border-color: color-mix(in srgb, #76b900 68%, var(--ifm-color-emphasis-300));
-  box-shadow: 0 0 0 2px color-mix(in srgb, #76b900 24%, transparent);
-  background: color-mix(in srgb, #76b900 16%, var(--ifm-background-color));
+  position: relative;
+  overflow: hidden;
+  border: 2px solid color-mix(in srgb, #76b900 68%, var(--ifm-color-emphasis-300));
+  background: linear-gradient(
+    135deg,
+    rgba(118, 185, 0, 0.10) 0%,
+    rgba(140, 200, 0, 0.16) 50%,
+    rgba(118, 185, 0, 0.10) 100%
+  );
+  box-shadow:
+    0 4px 12px rgba(118, 185, 0, 0.18),
+    inset 0 1px 0 rgba(255, 255, 255, 0.2);
+}
+
+.nvidiaMinorBump::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  mix-blend-mode: color-dodge;
+  z-index: 1;
+  background-image: linear-gradient(
+    115deg,
+    transparent 20%,
+    hsla(85, 60%, 70%, 0.2) 36%,
+    hsla(90, 65%, 65%, 0.35) 43%,
+    hsla(95, 60%, 60%, 0.4) 50%,
+    hsla(90, 65%, 65%, 0.35) 57%,
+    hsla(85, 60%, 70%, 0.2) 64%,
+    transparent 80%
+  );
+  background-size: 300% 300%;
+  background-position: 50% 50%;
+  opacity: 0.28;
+  filter: brightness(1.1) contrast(1.2);
 }
 
 .minorBump {
@@ -269,15 +335,15 @@
 .bumpTag {
   display: inline-block;
   margin-top: 0.35rem;
-  border: 1px solid #e6c200;
+  border: 1px solid #c9a800;
   border-radius: 999px;
   padding: 0.08rem 0.42rem;
   font-size: 0.7rem;
   font-weight: 700;
   letter-spacing: 0.02em;
   text-transform: uppercase;
-  background: linear-gradient(135deg, rgba(255, 215, 0, 0.25), rgba(255, 237, 78, 0.35));
-  color: #7a5c00;
+  background: #ffd700;
+  color: #5a3e00;
   position: relative;
   z-index: 2;
 }
@@ -285,15 +351,47 @@
 .minorTag {
   display: inline-block;
   margin-top: 0.35rem;
-  border: 1px solid #b8c6d8;
+  border: 1px solid #8fa8c0;
   border-radius: 999px;
   padding: 0.08rem 0.42rem;
   font-size: 0.7rem;
   font-weight: 700;
   letter-spacing: 0.02em;
   text-transform: uppercase;
-  background: linear-gradient(135deg, rgba(176, 196, 222, 0.3), rgba(192, 210, 235, 0.4));
-  color: #3a4a5a;
+  background: #c8d8e8;
+  color: #1e2d3a;
+  position: relative;
+  z-index: 2;
+}
+
+.nvidiaBumpTag {
+  display: inline-block;
+  margin-top: 0.35rem;
+  border: 1px solid #3d7a00;
+  border-radius: 999px;
+  padding: 0.08rem 0.42rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  background: #76b900;
+  color: #1a3600;
+  position: relative;
+  z-index: 2;
+}
+
+.nvidiaMinorTag {
+  display: inline-block;
+  margin-top: 0.35rem;
+  border: 1px solid #5a8a20;
+  border-radius: 999px;
+  padding: 0.08rem 0.42rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  background: #c8e090;
+  color: #1e3600;
   position: relative;
   z-index: 2;
 }

--- a/src/components/DriverVersionsCatalog.tsx
+++ b/src/components/DriverVersionsCatalog.tsx
@@ -10,6 +10,7 @@ interface VersionSet {
   hweKernel: string | null;
   mesa: string | null;
   nvidia: string | null;
+  gnome: string | null;
 }
 
 interface DriverRow {
@@ -95,6 +96,7 @@ function ReleaseNode({
   const nvidia = valueOrFallback(row.versions.nvidia);
   const mesa = valueOrFallback(row.versions.mesa);
   const hwe = row.versions.hweKernel;
+  const gnome = valueOrFallback(row.versions.gnome);
 
   const kernelMajor = majorNumber(row.versions.kernel);
   const previousKernelMajor = majorNumber(previousRow?.versions.kernel);
@@ -130,6 +132,40 @@ function ReleaseNode({
     nvidiaParts.major === previousNvidiaParts.major &&
     nvidiaParts.minor !== previousNvidiaParts.minor;
 
+  const mesaMajor = majorNumber(row.versions.mesa);
+  const previousMesaMajor = majorNumber(previousRow?.versions.mesa);
+  const mesaMajorBump =
+    mesaMajor !== null &&
+    previousMesaMajor !== null &&
+    previousMesaMajor !== mesaMajor;
+  const mesaParts = majorMinor(row.versions.mesa);
+  const previousMesaParts = majorMinor(previousRow?.versions.mesa);
+  const mesaMinorBump =
+    !mesaMajorBump &&
+    mesaParts.major !== null &&
+    previousMesaParts.major !== null &&
+    mesaParts.minor !== null &&
+    previousMesaParts.minor !== null &&
+    mesaParts.major === previousMesaParts.major &&
+    mesaParts.minor !== previousMesaParts.minor;
+
+  const gnomeMajor = majorNumber(row.versions.gnome);
+  const previousGnomeMajor = majorNumber(previousRow?.versions.gnome);
+  const gnomeMajorBump =
+    gnomeMajor !== null &&
+    previousGnomeMajor !== null &&
+    previousGnomeMajor !== gnomeMajor;
+  const gnomeParts = majorMinor(row.versions.gnome);
+  const previousGnomeParts = majorMinor(previousRow?.versions.gnome);
+  const gnomeMinorBump =
+    !gnomeMajorBump &&
+    gnomeParts.major !== null &&
+    previousGnomeParts.major !== null &&
+    gnomeParts.minor !== null &&
+    previousGnomeParts.minor !== null &&
+    gnomeParts.major === previousGnomeParts.major &&
+    gnomeParts.minor !== previousGnomeParts.minor;
+
   return (
     <article className={styles.timelineNode}>
       <div className={emphasize ? `${styles.nodeBody} ${styles.nodeBodyLatest}` : styles.nodeBody}>
@@ -159,6 +195,10 @@ function ReleaseNode({
             {kernelMajorBump && <span className={styles.bumpTag}>Major bump</span>}
             {!emphasize && kernelMinorBump && <span className={styles.minorTag}>Minor bump</span>}
           </div>
+          <div className={styles.majorVersionCard}>
+            <span className={styles.majorVersionLabel}>HWE Kernel</span>
+            <VersionValue value={hwe} />
+          </div>
           <div
             className={
               nvidiaMajorBump
@@ -173,13 +213,33 @@ function ReleaseNode({
             {nvidiaMajorBump && <span className={styles.nvidiaBumpTag}>Major bump</span>}
             {!emphasize && nvidiaMinorBump && <span className={styles.nvidiaMinorTag}>Minor bump</span>}
           </div>
-          <div className={styles.majorVersionCard}>
+          <div
+            className={
+              mesaMajorBump
+                ? `${styles.majorVersionCard} ${styles.mesaCard} ${styles.mesaMajorBump}`
+                : !emphasize && mesaMinorBump
+                  ? `${styles.majorVersionCard} ${styles.mesaCard} ${styles.mesaMinorBump}`
+                  : `${styles.majorVersionCard} ${styles.mesaCard}`
+            }
+          >
             <span className={styles.majorVersionLabel}>Mesa</span>
             <VersionValue value={mesa} />
+            {mesaMajorBump && <span className={styles.mesaBumpTag}>Major bump</span>}
+            {!emphasize && mesaMinorBump && <span className={styles.mesaMinorTag}>Minor bump</span>}
           </div>
-          <div className={styles.majorVersionCard}>
-            <span className={styles.majorVersionLabel}>HWE</span>
-            <VersionValue value={hwe} />
+          <div
+            className={
+              gnomeMajorBump
+                ? `${styles.majorVersionCard} ${styles.gnomeCard} ${styles.gnomeMajorBump}`
+                : !emphasize && gnomeMinorBump
+                  ? `${styles.majorVersionCard} ${styles.gnomeCard} ${styles.gnomeMinorBump}`
+                  : `${styles.majorVersionCard} ${styles.gnomeCard}`
+            }
+          >
+            <span className={styles.majorVersionLabel}>GNOME</span>
+            <VersionValue value={gnome} />
+            {gnomeMajorBump && <span className={styles.gnomeBumpTag}>Major bump</span>}
+            {!emphasize && gnomeMinorBump && <span className={styles.gnomeMinorTag}>Minor bump</span>}
           </div>
         </div>
 

--- a/src/components/DriverVersionsCatalog.tsx
+++ b/src/components/DriverVersionsCatalog.tsx
@@ -38,7 +38,7 @@ interface DriverCatalog {
   streams?: DriverStream[];
 }
 
-const catalog = driverVersionsData as DriverCatalog;
+const catalog = driverVersionsData as unknown as DriverCatalog;
 
 function formatDate(value: string | null | undefined) {
   if (!value) return "Unknown";

--- a/src/components/DriverVersionsCatalog.tsx
+++ b/src/components/DriverVersionsCatalog.tsx
@@ -170,8 +170,8 @@ function ReleaseNode({
           >
             <span className={styles.majorVersionLabel}>NVIDIA</span>
             <VersionValue value={nvidia} />
-            {nvidiaMajorBump && <span className={styles.bumpTag}>Major bump</span>}
-            {!emphasize && nvidiaMinorBump && <span className={styles.minorTag}>Minor bump</span>}
+            {nvidiaMajorBump && <span className={styles.nvidiaBumpTag}>Major bump</span>}
+            {!emphasize && nvidiaMinorBump && <span className={styles.nvidiaMinorTag}>Minor bump</span>}
           </div>
           <div className={styles.majorVersionCard}>
             <span className={styles.majorVersionLabel}>Mesa</span>

--- a/src/components/DriverVersionsCatalog.tsx
+++ b/src/components/DriverVersionsCatalog.tsx
@@ -185,7 +185,7 @@ function ReleaseNode({
             className={
               kernelMajorBump
                 ? `${styles.majorVersionCard} ${styles.majorBump}`
-                : !emphasize && kernelMinorBump
+                : kernelMinorBump
                   ? `${styles.majorVersionCard} ${styles.minorBump}`
                   : styles.majorVersionCard
             }
@@ -193,17 +193,19 @@ function ReleaseNode({
             <span className={styles.majorVersionLabel}>Kernel</span>
             <VersionValue value={kernel} />
             {kernelMajorBump && <span className={styles.bumpTag}>Major bump</span>}
-            {!emphasize && kernelMinorBump && <span className={styles.minorTag}>Minor bump</span>}
+            {kernelMinorBump && <span className={styles.minorTag}>Minor bump</span>}
           </div>
-          <div className={styles.majorVersionCard}>
-            <span className={styles.majorVersionLabel}>HWE Kernel</span>
-            <VersionValue value={hwe} />
-          </div>
+          {hwe !== null && (
+            <div className={styles.majorVersionCard}>
+              <span className={styles.majorVersionLabel}>HWE Kernel</span>
+              <VersionValue value={hwe} />
+            </div>
+          )}
           <div
             className={
               nvidiaMajorBump
                 ? `${styles.majorVersionCard} ${styles.nvidiaCard} ${styles.nvidiaMajorBump}`
-                : !emphasize && nvidiaMinorBump
+                : nvidiaMinorBump
                   ? `${styles.majorVersionCard} ${styles.nvidiaCard} ${styles.nvidiaMinorBump}`
                   : `${styles.majorVersionCard} ${styles.nvidiaCard}`
             }
@@ -211,13 +213,13 @@ function ReleaseNode({
             <span className={styles.majorVersionLabel}>NVIDIA</span>
             <VersionValue value={nvidia} />
             {nvidiaMajorBump && <span className={styles.nvidiaBumpTag}>Major bump</span>}
-            {!emphasize && nvidiaMinorBump && <span className={styles.nvidiaMinorTag}>Minor bump</span>}
+            {nvidiaMinorBump && <span className={styles.nvidiaMinorTag}>Minor bump</span>}
           </div>
           <div
             className={
               mesaMajorBump
                 ? `${styles.majorVersionCard} ${styles.mesaCard} ${styles.mesaMajorBump}`
-                : !emphasize && mesaMinorBump
+                : mesaMinorBump
                   ? `${styles.majorVersionCard} ${styles.mesaCard} ${styles.mesaMinorBump}`
                   : `${styles.majorVersionCard} ${styles.mesaCard}`
             }
@@ -225,13 +227,13 @@ function ReleaseNode({
             <span className={styles.majorVersionLabel}>Mesa</span>
             <VersionValue value={mesa} />
             {mesaMajorBump && <span className={styles.mesaBumpTag}>Major bump</span>}
-            {!emphasize && mesaMinorBump && <span className={styles.mesaMinorTag}>Minor bump</span>}
+            {mesaMinorBump && <span className={styles.mesaMinorTag}>Minor bump</span>}
           </div>
           <div
             className={
               gnomeMajorBump
                 ? `${styles.majorVersionCard} ${styles.gnomeCard} ${styles.gnomeMajorBump}`
-                : !emphasize && gnomeMinorBump
+                : gnomeMinorBump
                   ? `${styles.majorVersionCard} ${styles.gnomeCard} ${styles.gnomeMinorBump}`
                   : `${styles.majorVersionCard} ${styles.gnomeCard}`
             }
@@ -239,7 +241,7 @@ function ReleaseNode({
             <span className={styles.majorVersionLabel}>GNOME</span>
             <VersionValue value={gnome} />
             {gnomeMajorBump && <span className={styles.gnomeBumpTag}>Major bump</span>}
-            {!emphasize && gnomeMinorBump && <span className={styles.gnomeMinorTag}>Minor bump</span>}
+            {gnomeMinorBump && <span className={styles.gnomeMinorTag}>Minor bump</span>}
           </div>
         </div>
 

--- a/src/components/FeedItems.module.css
+++ b/src/components/FeedItems.module.css
@@ -204,7 +204,8 @@
   vertical-align: middle;
 }
 
-.feedItem:hover .copyButton {
+.feedItem:hover .copyButton,
+.copyButton:focus-visible {
   opacity: 1;
 }
 

--- a/src/components/ImagesCatalog.module.css
+++ b/src/components/ImagesCatalog.module.css
@@ -287,6 +287,57 @@
   word-break: break-all;
 }
 
+/* Copyable code block: same visual as bare <code> but with hover-reveal copy button */
+.copyableCode {
+  position: relative;
+  display: block;
+  margin-bottom: 0.4rem;
+}
+
+.copyableCode code {
+  display: block;
+  padding: 0.45rem 3rem 0.45rem 0.55rem; /* extra right space for the button */
+  border-radius: 8px;
+  background: var(--ifm-color-emphasis-100);
+  word-break: break-all;
+  font-size: var(--ifm-code-font-size);
+  margin-bottom: 0;
+}
+
+.copyableCodeBtn {
+  position: absolute;
+  top: 50%;
+  right: 0.4rem;
+  transform: translateY(-50%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 4px;
+  padding: 0.1em 0.4em;
+  font-size: 0.8rem;
+  color: var(--ifm-color-emphasis-500);
+  cursor: pointer;
+  opacity: 0;
+  transition:
+    opacity 0.15s ease,
+    color 0.15s ease,
+    border-color 0.15s ease;
+  line-height: 1;
+}
+
+.copyableCode:hover .copyableCodeBtn,
+.copyableCodeBtn:focus-visible {
+  opacity: 1;
+}
+
+.copyableCodeBtn:hover {
+  color: var(--ifm-color-primary);
+  border-color: var(--ifm-color-primary);
+  background: none;
+}
+
 .section :global(.tabs) {
   margin-top: 0.35rem;
   border: 0;

--- a/src/components/ImagesCatalog.module.css
+++ b/src/components/ImagesCatalog.module.css
@@ -287,56 +287,6 @@
   word-break: break-all;
 }
 
-/* Copyable code block: same visual as bare <code> but with hover-reveal copy button */
-.copyableCode {
-  position: relative;
-  display: block;
-  margin-bottom: 0.4rem;
-}
-
-.copyableCode code {
-  display: block;
-  padding: 0.45rem 3rem 0.45rem 0.55rem; /* extra right space for the button */
-  border-radius: 8px;
-  background: var(--ifm-color-emphasis-100);
-  word-break: break-all;
-  font-size: var(--ifm-code-font-size);
-  margin-bottom: 0;
-}
-
-.copyableCodeBtn {
-  position: absolute;
-  top: 50%;
-  right: 0.4rem;
-  transform: translateY(-50%);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: none;
-  border: 1px solid var(--ifm-color-emphasis-300);
-  border-radius: 4px;
-  padding: 0.1em 0.4em;
-  font-size: 0.8rem;
-  color: var(--ifm-color-emphasis-500);
-  cursor: pointer;
-  opacity: 0;
-  transition:
-    opacity 0.15s ease,
-    color 0.15s ease,
-    border-color 0.15s ease;
-  line-height: 1;
-}
-
-.copyableCode:hover .copyableCodeBtn,
-.copyableCodeBtn:focus-visible {
-  opacity: 1;
-}
-
-.copyableCodeBtn:hover {
-  color: var(--ifm-color-primary);
-  border-color: var(--ifm-color-primary);
-  background: none;
-}
 
 .section :global(.tabs) {
   margin-top: 0.35rem;

--- a/src/components/ImagesCatalog.tsx
+++ b/src/components/ImagesCatalog.tsx
@@ -1,11 +1,38 @@
-import React from "react";
+import React, { useState, useCallback } from "react";
 import Link from "@docusaurus/Link";
 import Heading from "@theme/Heading";
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import styles from "./ImagesCatalog.module.css";
-import sbomData from "@site/static/data/sbom-attestations.json";
-import type { SbomAttestationsData } from "../types/sbom";
+
+// Copyable code block — styled like a <code> element with a hover-reveal copy button
+function CopyableCode({ children }: { children: string }) {
+  const [copied, setCopied] = useState(false);
+  const handleCopy = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      navigator.clipboard.writeText(children).then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      });
+    },
+    [children],
+  );
+  return (
+    <div className={styles.copyableCode}>
+      <code>{children}</code>
+      <button
+        onClick={handleCopy}
+        className={styles.copyableCodeBtn}
+        title={copied ? "Copied!" : "Copy to clipboard"}
+        aria-label={copied ? "Copied!" : `Copy ${children}`}
+      >
+        {copied ? "✓" : "⎘"}
+      </button>
+    </div>
+  );
+}
 
 interface StreamInfo {
   label: string;
@@ -24,7 +51,6 @@ interface Product {
   id: string;
   name: string;
   org: string;
-  package: string;
   summary: string;
   artwork: "bluefin" | "achillobator" | "dakotaraptor";
   packagePageUrl: string;
@@ -75,8 +101,7 @@ function sourceText(source: "live" | "cache" | "unavailable", kind: string) {
 
 function sourceClass(source: "live" | "cache" | "unavailable") {
   if (source === "cache") return `${styles.statChip} ${styles.chipCache}`;
-  if (source === "unavailable")
-    return `${styles.statChip} ${styles.chipUnavailable}`;
+  if (source === "unavailable") return `${styles.statChip} ${styles.chipUnavailable}`;
   return styles.statChip;
 }
 
@@ -111,14 +136,12 @@ function StreamList({
           </div>
           {preferNvidia ? (
             entry.nvidiaCommand ? (
-              <code>{entry.nvidiaCommand}</code>
+              <CopyableCode>{entry.nvidiaCommand}</CopyableCode>
             ) : (
-              <span className={styles.emptyText}>
-                No Nvidia variant for this tag.
-              </span>
+              <span className={styles.emptyText}>No Nvidia variant for this tag.</span>
             )
           ) : (
-            <code>{entry.command}</code>
+            <CopyableCode>{entry.command}</CopyableCode>
           )}
         </li>
       ))}
@@ -146,30 +169,6 @@ function formatDate(value?: string | null) {
   });
 }
 
-/**
- * Look up the most-recent attestation result for a product from the SBOM cache.
- * We find the first stream in the cache whose org/package matches the product,
- * then return the latest (lexicographically greatest date key) release entry.
- */
-function latestAttestationForProduct(
-  productOrg: string,
-  productPackage: string,
-) {
-  const cache = sbomData as unknown as SbomAttestationsData;
-  if (!cache?.streams) return null;
-
-  for (const stream of Object.values(cache.streams)) {
-    if (stream.org !== productOrg || stream.package !== productPackage)
-      continue;
-    const keys = Object.keys(stream.releases || {})
-      .sort()
-      .reverse();
-    if (keys.length === 0) continue;
-    return stream.releases[keys[0]];
-  }
-  return null;
-}
-
 export default function ImagesCatalogComponent(): React.JSX.Element {
   const [catalog, setCatalog] = React.useState<ImagesCatalog>({ products: [] });
 
@@ -193,16 +192,14 @@ export default function ImagesCatalogComponent(): React.JSX.Element {
   }, []);
 
   const products = Array.isArray(catalog?.products) ? catalog.products : [];
-  const [nvidiaModeByProduct, setNvidiaModeByProduct] = React.useState<
-    Record<string, boolean>
-  >({});
-  const dakotaProducts = products.filter((product) =>
-    product.name.includes("Dakota"),
+  const [nvidiaModeByProduct, setNvidiaModeByProduct] = React.useState<Record<string, boolean>>(
+    {},
   );
+  const dakotaProducts = products.filter((product) => product.name.includes("Dakota"));
   const ltsProducts = products.filter(
     (product) =>
       ((product.name.includes("LTS") || product.name.includes("GDX")) &&
-        !product.name.includes("Dakota")) ||
+      !product.name.includes("Dakota")) ||
       product.id === "ublue-bluefin-lts" ||
       product.id === "ublue-bluefin-dx-lts" ||
       product.id === "ublue-bluefin-gdx",
@@ -232,335 +229,262 @@ export default function ImagesCatalogComponent(): React.JSX.Element {
         return a.name.localeCompare(b.name);
       })
       .map((product) => {
-        const tone =
-          product.artwork === "dakotaraptor"
-            ? styles.cardDakota
-            : product.artwork === "achillobator"
-              ? styles.cardLts
-              : styles.cardBluefin;
-        const digestShort = product.metadata?.digestShort || "Unavailable";
-        const digestFull = product.metadata?.digest || null;
-        const digestLink = product.metadata?.digestLink;
-        const ostreeShort = product.metadata?.labels?.ostreeCommit?.slice(
-          0,
-          12,
-        );
-        const releaseUrl = assetsLink(product.versions?.release?.url);
-        const lastValidated = formatDate(catalog.generatedAt || null);
-        const lastPublished = formatDate(product.lastPublishedAt || null);
-        const hasNvidiaVariant =
-          product.streams.some((entry) => Boolean(entry.nvidiaCommand)) ||
-          product.testingStreams.some((entry) => Boolean(entry.nvidiaCommand));
-        const nvidiaEnabled = Boolean(nvidiaModeByProduct[product.id]);
-        const latestAttestation = latestAttestationForProduct(
-          product.org,
-          product.package,
-        );
+      const tone =
+        product.artwork === "dakotaraptor"
+          ? styles.cardDakota
+          : product.artwork === "achillobator"
+            ? styles.cardLts
+            : styles.cardBluefin;
+      const digestShort = product.metadata?.digestShort || "Unavailable";
+      const digestFull = product.metadata?.digest || null;
+      const digestLink = product.metadata?.digestLink;
+      const ostreeShort = product.metadata?.labels?.ostreeCommit?.slice(0, 12);
+      const releaseUrl = assetsLink(product.versions?.release?.url);
+      const lastValidated = formatDate(catalog.generatedAt || null);
+      const lastPublished = formatDate(product.lastPublishedAt || null);
+      const hasNvidiaVariant =
+        product.streams.some((entry) => Boolean(entry.nvidiaCommand)) ||
+        product.testingStreams.some((entry) => Boolean(entry.nvidiaCommand));
+      const nvidiaEnabled = Boolean(nvidiaModeByProduct[product.id]);
 
-        return (
-          <article key={product.id} className={`${styles.card} ${tone}`}>
-            <header className={styles.cardHeader}>
-              <Heading as="h2" className={styles.cardTitle}>
-                {product.name}
+      return (
+        <article key={product.id} className={`${styles.card} ${tone}`}>
+          <header className={styles.cardHeader}>
+            <Heading as="h2" className={styles.cardTitle}>
+              {product.name}
+            </Heading>
+            <span className={styles.registryBadge}>{product.org}</span>
+          </header>
+
+          <section className={styles.linkRow}>
+            <Link to={product.packagePageUrl} target="_blank" rel="noopener noreferrer">
+              Package Page
+            </Link>
+            {product.isoSectionLink && (
+              <>
+                <span>·</span>
+                <Link to={product.isoSectionLink}>Download ISO</Link>
+              </>
+            )}
+            {releaseUrl && (
+              <>
+                <span>·</span>
+                <Link to={releaseUrl} target="_blank" rel="noopener noreferrer">
+                  Release Assets
+                </Link>
+              </>
+            )}
+            {digestLink ? (
+              <>
+                <span>·</span>
+                <Link
+                  to={digestLink}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  title={digestFull || digestShort}
+                >
+                  Digest {digestShort}
+                </Link>
+              </>
+            ) : (
+              <>
+                <span>·</span>
+                <span>Digest {digestShort}</span>
+              </>
+            )}
+            {ostreeShort && (
+              <>
+                <span>·</span>
+                <span>OSTree {ostreeShort}</span>
+              </>
+            )}
+          </section>
+
+          <p className={styles.summary}>{product.summary}</p>
+
+          <div className={styles.statsRow}>
+            <span className={styles.statChip}>
+              <strong>Pulls:</strong> {product.downloads.display}
+            </span>
+            <span className={sourceClass(product.downloads.source)}>
+              {sourceText(product.downloads.source, "Downloads")}
+            </span>
+            <span className={sourceClass(product.metadataSource)}>
+              {sourceText(product.metadataSource, "Metadata")}
+            </span>
+          </div>
+
+          <p className={styles.validationMeta}>
+            Last validated: <strong>{lastValidated}</strong> · Last published: <strong>{lastPublished}</strong>
+          </p>
+
+          <section className={`${styles.section} ${styles.focusSection} ${styles.streamsSection}`}>
+            <div className={styles.sectionHeader}>
+              <Heading as="h3" className={styles.sectionTitle}>
+                Streams
               </Heading>
-              <span className={styles.registryBadge}>{product.org}</span>
-            </header>
-
-            <section className={styles.linkRow}>
-              <Link
-                to={product.packagePageUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Package Page
-              </Link>
-              {product.isoSectionLink && (
-                <>
-                  <span>·</span>
-                  <Link to={product.isoSectionLink}>Download ISO</Link>
-                </>
+              {hasNvidiaVariant && (
+                <div className={styles.nvidiaControl}>
+                  <p className={styles.nvidiaToggleLabel}>Graphics Drivers</p>
+                  <p className={styles.nvidiaToggleQuestion}>Add Nvidia driver?</p>
+                  <div className={styles.nvidiaToggleGroup} role="group" aria-label="Nvidia driver toggle">
+                    <button
+                      type="button"
+                      className={`button button--sm ${!nvidiaEnabled ? "button--primary" : "button--secondary"}`}
+                      aria-pressed={!nvidiaEnabled}
+                      onClick={() =>
+                        setNvidiaModeByProduct((current) => ({
+                          ...current,
+                          [product.id]: false,
+                        }))
+                      }
+                    >
+                      No
+                    </button>
+                    <button
+                      type="button"
+                      className={`button button--sm ${nvidiaEnabled ? "button--primary" : "button--secondary"}`}
+                      aria-pressed={nvidiaEnabled}
+                      onClick={() =>
+                        setNvidiaModeByProduct((current) => ({
+                          ...current,
+                          [product.id]: true,
+                        }))
+                      }
+                    >
+                      Yes
+                    </button>
+                  </div>
+                </div>
               )}
-              {releaseUrl && (
-                <>
-                  <span>·</span>
-                  <Link
-                    to={releaseUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Release Assets
-                  </Link>
-                </>
-              )}
-              {digestLink ? (
-                <>
-                  <span>·</span>
-                  <Link
-                    to={digestLink}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    title={digestFull || digestShort}
-                  >
-                    Digest {digestShort}
-                  </Link>
-                </>
-              ) : (
-                <>
-                  <span>·</span>
-                  <span>Digest {digestShort}</span>
-                </>
-              )}
-              {ostreeShort && (
-                <>
-                  <span>·</span>
-                  <span>OSTree {ostreeShort}</span>
-                </>
-              )}
-            </section>
-
-            <p className={styles.summary}>{product.summary}</p>
-
-            <div className={styles.statsRow}>
-              <span className={styles.statChip}>
-                <strong>Pulls:</strong> {product.downloads.display}
-              </span>
-              <span className={sourceClass(product.downloads.source)}>
-                {sourceText(product.downloads.source, "Downloads")}
-              </span>
-              <span className={sourceClass(product.metadataSource)}>
-                {sourceText(product.metadataSource, "Metadata")}
-              </span>
             </div>
 
-            <p className={styles.validationMeta}>
-              Last validated: <strong>{lastValidated}</strong> · Last published:{" "}
-              <strong>{lastPublished}</strong>
-            </p>
-
-            <section
-              className={`${styles.section} ${styles.focusSection} ${styles.streamsSection}`}
-            >
-              <div className={styles.sectionHeader}>
-                <Heading as="h3" className={styles.sectionTitle}>
-                  Streams
-                </Heading>
-                {hasNvidiaVariant && (
-                  <div className={styles.nvidiaControl}>
-                    <p className={styles.nvidiaToggleLabel}>Graphics Drivers</p>
-                    <p className={styles.nvidiaToggleQuestion}>
-                      Add Nvidia driver?
+            {product.streams.length > 0 ? (
+              <Tabs
+                groupId={`streams-${product.id}`}
+                values={product.streams.map((entry) => ({
+                  label: entry.label,
+                  value: tabValue(entry.tag),
+                }))}
+              >
+                {product.streams.map((entry) => (
+                  <TabItem key={entry.tag} value={tabValue(entry.tag)}>
+                    <p className={styles.tabCopy}>
+                      Use this command to switch to the <strong>{entry.label.toLowerCase()}</strong> channel for this image.
+                      It is the quickest way to stay on that release stream.
                     </p>
-                    <div
-                      className={styles.nvidiaToggleGroup}
-                      role="group"
-                      aria-label="Nvidia driver toggle"
-                    >
-                      <button
-                        type="button"
-                        className={`button button--sm ${!nvidiaEnabled ? "button--primary" : "button--secondary"}`}
-                        aria-pressed={!nvidiaEnabled}
-                        onClick={() =>
-                          setNvidiaModeByProduct((current) => ({
-                            ...current,
-                            [product.id]: false,
-                          }))
-                        }
-                      >
-                        No
-                      </button>
-                      <button
-                        type="button"
-                        className={`button button--sm ${nvidiaEnabled ? "button--primary" : "button--secondary"}`}
-                        aria-pressed={nvidiaEnabled}
-                        onClick={() =>
-                          setNvidiaModeByProduct((current) => ({
-                            ...current,
-                            [product.id]: true,
-                          }))
-                        }
-                      >
-                        Yes
-                      </button>
-                    </div>
-                  </div>
-                )}
-              </div>
-
-              {product.streams.length > 0 ? (
-                <Tabs
-                  groupId={`streams-${product.id}`}
-                  values={product.streams.map((entry) => ({
-                    label: entry.label,
-                    value: tabValue(entry.tag),
-                  }))}
-                >
-                  {product.streams.map((entry) => (
-                    <TabItem key={entry.tag} value={tabValue(entry.tag)}>
-                      <p className={styles.tabCopy}>
-                        Use this command to switch to the{" "}
-                        <strong>{entry.label.toLowerCase()}</strong> channel for
-                        this image. It is the quickest way to stay on that
-                        release stream.
-                      </p>
-                      {nvidiaEnabled ? (
-                        entry.nvidiaCommand ? (
-                          <>
-                            <div className={styles.streamVersionPills}>
-                              <span className={styles.versionPill}>
-                                <strong>GNOME</strong>{" "}
-                                {entry.versions?.gnome || "Unknown"}
-                              </span>
-                              <span className={styles.versionPill}>
-                                <strong>Linux</strong>{" "}
-                                {entry.versions?.kernel || "Unknown"}
-                              </span>
-                              <span className={styles.versionPill}>
-                                <strong>NVIDIA</strong>{" "}
-                                {entry.versions?.nvidia || "Unknown"}
-                              </span>
-                            </div>
-                            <code>{entry.nvidiaCommand}</code>
-                          </>
-                        ) : (
-                          <p className={styles.emptyText}>
-                            No Nvidia variant published for this stream tag.
-                          </p>
-                        )
-                      ) : (
+                    {nvidiaEnabled ? (
+                      entry.nvidiaCommand ? (
                         <>
                           <div className={styles.streamVersionPills}>
                             <span className={styles.versionPill}>
-                              <strong>GNOME</strong>{" "}
-                              {entry.versions?.gnome || "Unknown"}
+                              <strong>GNOME</strong> {entry.versions?.gnome || "Unknown"}
                             </span>
                             <span className={styles.versionPill}>
-                              <strong>Linux</strong>{" "}
-                              {entry.versions?.kernel || "Unknown"}
+                              <strong>Linux</strong> {entry.versions?.kernel || "Unknown"}
                             </span>
-                            {entry.versions?.nvidia && (
-                              <span className={styles.versionPill}>
-                                <strong>NVIDIA</strong> {entry.versions.nvidia}
-                              </span>
-                            )}
+                            <span className={styles.versionPill}>
+                              <strong>NVIDIA</strong> {entry.versions?.nvidia || "Unknown"}
+                            </span>
                           </div>
-                          <code>{entry.command}</code>
+                          <code>{entry.nvidiaCommand}</code>
                         </>
-                      )}
-                    </TabItem>
-                  ))}
-                </Tabs>
-              ) : (
-                <p className={styles.emptyText}>No active tags.</p>
-              )}
-
-              <details className={styles.testingDetails}>
-                <summary>
-                  Testing Branches ({product.testingStreams.length})
-                </summary>
-                <StreamList
-                  streams={product.testingStreams}
-                  preferNvidia={nvidiaEnabled}
-                />
-              </details>
-            </section>
-
-            <section
-              className={`${styles.section} ${styles.focusSection} ${styles.securitySection}`}
-            >
-              <Heading as="h3" className={styles.sectionTitle}>
-                Signing and SBOM
-              </Heading>
-              {product.security?.cosignKeyUrl ? (
-                <p className={styles.securityText}>
-                  Key: <code>{product.security.cosignKeyUrl}</code>
-                </p>
-              ) : (
-                <p className={styles.securityText}>
-                  No published cosign key URL in this catalog.
-                </p>
-              )}
-
-              <Tabs
-                groupId={`security-${product.id}`}
-                values={[
-                  { label: "Verify Signature", value: "verify-signature" },
-                  { label: "Verify Provenance", value: "verify-provenance" },
-                  { label: "Generate SBOM", value: "generate-sbom" },
-                ]}
-              >
-                <TabItem value="verify-signature">
-                  <p className={styles.tabCopy}>
-                    Signature verification confirms this image was signed by the
-                    expected maintainers and helps detect tampering before
-                    deployment.{" "}
-                    <Link
-                      to="https://docs.sigstore.dev/cosign/verifying/verify/"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      Learn more
-                    </Link>
-                    .
-                  </p>
-                  {product.security?.verifyCommand && (
-                    <code>{product.security.verifyCommand}</code>
-                  )}
-                </TabItem>
-                <TabItem value="verify-provenance">
-                  <p className={styles.tabCopy}>
-                    Provenance attestation lets you validate how the image was
-                    built in CI so you can make trust decisions from evidence.{" "}
-                    <Link
-                      to="https://slsa.dev/"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      Learn more
-                    </Link>
-                    .
-                  </p>
-                  {latestAttestation && (
-                    <p className={styles.tabCopy}>
-                      {latestAttestation.attestation.verified
-                        ? `Latest release (${latestAttestation.tag}): attestation verified.`
-                        : latestAttestation.attestation.present
-                          ? `Latest release (${latestAttestation.tag}): attestation present but verification failed.`
-                          : `Latest release (${latestAttestation.tag}): no attestation found.`}
-                    </p>
-                  )}
-                  {product.security?.attestCommand && (
-                    <code>{product.security.attestCommand}</code>
-                  )}
-                  {product.security?.attestCommand &&
-                    product.security.hasAttestation === false &&
-                    !latestAttestation?.attestation.present && (
-                      <p className={styles.tabCopy}>
-                        Note: attestations are not yet published for this image.
-                        The command is provided for when they are.
-                      </p>
+                      ) : (
+                        <p className={styles.emptyText}>No Nvidia variant published for this stream tag.</p>
+                      )
+                    ) : (
+                      <>
+                        <div className={styles.streamVersionPills}>
+                          <span className={styles.versionPill}>
+                            <strong>GNOME</strong> {entry.versions?.gnome || "Unknown"}
+                          </span>
+                          <span className={styles.versionPill}>
+                            <strong>Linux</strong> {entry.versions?.kernel || "Unknown"}
+                          </span>
+                          {entry.versions?.nvidia && (
+                            <span className={styles.versionPill}>
+                              <strong>NVIDIA</strong> {entry.versions.nvidia}
+                            </span>
+                          )}
+                        </div>
+                        <code>{entry.command}</code>
+                      </>
                     )}
-                </TabItem>
-                <TabItem value="generate-sbom">
-                  <p className={styles.tabCopy}>
-                    SBOM generation gives you a component inventory for audits,
-                    policy checks, and vulnerability triage workflows.{" "}
-                    <Link
-                      to="https://github.com/anchore/syft"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      Learn more
-                    </Link>
-                    .
-                  </p>
-                  {product.security?.sbomCommand && (
-                    <code>{product.security.sbomCommand}</code>
-                  )}
-                </TabItem>
+                  </TabItem>
+                ))}
               </Tabs>
-            </section>
-          </article>
-        );
+            ) : (
+              <p className={styles.emptyText}>No active tags.</p>
+            )}
+
+            <details className={styles.testingDetails}>
+              <summary>Testing Branches ({product.testingStreams.length})</summary>
+              <StreamList streams={product.testingStreams} preferNvidia={nvidiaEnabled} />
+            </details>
+          </section>
+
+          <section className={`${styles.section} ${styles.focusSection} ${styles.securitySection}`}>
+            <Heading as="h3" className={styles.sectionTitle}>
+              Signing and SBOM
+            </Heading>
+            {product.security?.cosignKeyUrl ? (
+              <p className={styles.securityText}>
+                Key: <code>{product.security.cosignKeyUrl}</code>
+              </p>
+            ) : (
+              <p className={styles.securityText}>No published cosign key URL in this catalog.</p>
+            )}
+
+            <Tabs
+              groupId={`security-${product.id}`}
+              values={[
+                { label: "Verify Signature", value: "verify-signature" },
+                { label: "Verify Provenance", value: "verify-provenance" },
+                { label: "Generate SBOM", value: "generate-sbom" },
+              ]}
+            >
+              <TabItem value="verify-signature">
+                <p className={styles.tabCopy}>
+                  Signature verification confirms this image was signed by the expected maintainers and helps detect tampering before deployment.
+                  {" "}
+                  <Link to="https://docs.sigstore.dev/cosign/verifying/verify/" target="_blank" rel="noopener noreferrer">
+                    Learn more
+                  </Link>
+                  .
+                </p>
+                {product.security?.verifyCommand && <CopyableCode>{product.security.verifyCommand}</CopyableCode>}
+              </TabItem>
+              <TabItem value="verify-provenance">
+                <p className={styles.tabCopy}>
+                  Provenance attestation lets you validate how the image was built in CI so you can make trust decisions from evidence.
+                  {" "}
+                  <Link to="https://slsa.dev/" target="_blank" rel="noopener noreferrer">
+                    Learn more
+                  </Link>
+                  .
+                </p>
+                {product.security?.attestCommand && <CopyableCode>{product.security.attestCommand}</CopyableCode>}
+                {product.security?.attestCommand && product.security.hasAttestation === false && (
+                  <p className={styles.tabCopy}>
+                    Note: attestations are not yet published for this image. The command is provided for when they are.
+                  </p>
+                )}
+              </TabItem>
+              <TabItem value="generate-sbom">
+                <p className={styles.tabCopy}>
+                  SBOM generation gives you a component inventory for audits, policy checks, and vulnerability triage workflows.
+                  {" "}
+                  <Link to="https://github.com/anchore/syft" target="_blank" rel="noopener noreferrer">
+                    Learn more
+                  </Link>
+                  .
+                </p>
+                {product.security?.sbomCommand && <CopyableCode>{product.security.sbomCommand}</CopyableCode>}
+              </TabItem>
+            </Tabs>
+          </section>
+        </article>
+      );
       });
 
   return (
@@ -570,12 +494,11 @@ export default function ImagesCatalogComponent(): React.JSX.Element {
           Bluefin
         </Heading>
         <p className={styles.groupHint}>
-          Recommended for most users who want current Bluefin releases and fast
-          feature delivery.
+          Recommended for most users who want current Bluefin releases and fast feature delivery.
         </p>
         <div className="alert alert--info" role="note">
-          Rebasing between Bluefin and Bluefin LTS image families is not
-          supported. Choose the family you intend to stay on.
+          Rebasing between Bluefin and Bluefin LTS image families is not supported.
+          Choose the family you intend to stay on.
         </div>
         <div className={styles.cards}>{renderCards(mainlineProducts)}</div>
       </section>
@@ -585,13 +508,11 @@ export default function ImagesCatalogComponent(): React.JSX.Element {
           Bluefin LTS and GDX
         </Heading>
         <p className={styles.groupHint}>
-          Recommended for longer support windows, conservative upgrades, and
-          production-focused workstations.
+          Recommended for longer support windows, conservative upgrades, and production-focused workstations.
         </p>
         <div className="alert alert--info" role="note">
-          Rebasing between Bluefin and Bluefin LTS image families is not
-          supported. Plan migrations as fresh installs or supported upgrade
-          paths.
+          Rebasing between Bluefin and Bluefin LTS image families is not supported.
+          Plan migrations as fresh installs or supported upgrade paths.
         </div>
         <div className={styles.cards}>{renderCards(ltsProducts)}</div>
       </section>
@@ -601,12 +522,10 @@ export default function ImagesCatalogComponent(): React.JSX.Element {
           Dakota
         </Heading>
         <p className={styles.groupHint}>
-          Recommended for users evaluating the next-generation Dakota track and
-          related experiments.
+          Recommended for users evaluating the next-generation Dakota track and related experiments.
         </p>
         <div className="alert alert--info" role="note">
-          Dakota is a separate image track. Rebasing between Bluefin and Bluefin
-          LTS families and Dakota is not supported.
+          Dakota is a separate image track. Rebasing between Bluefin and Bluefin LTS families and Dakota is not supported.
         </div>
         <div className={styles.cards}>{renderCards(dakotaProducts)}</div>
       </section>

--- a/src/components/ImagesCatalog.tsx
+++ b/src/components/ImagesCatalog.tsx
@@ -387,7 +387,7 @@ export default function ImagesCatalogComponent(): React.JSX.Element {
                               <strong>NVIDIA</strong> {entry.versions?.nvidia || "Unknown"}
                             </span>
                           </div>
-                          <code>{entry.nvidiaCommand}</code>
+                          <CopyableCode>{entry.nvidiaCommand}</CopyableCode>
                         </>
                       ) : (
                         <p className={styles.emptyText}>No Nvidia variant published for this stream tag.</p>
@@ -407,7 +407,7 @@ export default function ImagesCatalogComponent(): React.JSX.Element {
                             </span>
                           )}
                         </div>
-                        <code>{entry.command}</code>
+                        <CopyableCode>{entry.command}</CopyableCode>
                       </>
                     )}
                   </TabItem>

--- a/src/components/ImagesCatalog.tsx
+++ b/src/components/ImagesCatalog.tsx
@@ -1,38 +1,11 @@
-import React, { useState, useCallback } from "react";
+import React from "react";
 import Link from "@docusaurus/Link";
 import Heading from "@theme/Heading";
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
+import CodeBlock from "@theme/CodeBlock";
 import styles from "./ImagesCatalog.module.css";
 
-// Copyable code block — styled like a <code> element with a hover-reveal copy button
-function CopyableCode({ children }: { children: string }) {
-  const [copied, setCopied] = useState(false);
-  const handleCopy = useCallback(
-    (e: React.MouseEvent) => {
-      e.preventDefault();
-      e.stopPropagation();
-      navigator.clipboard.writeText(children).then(() => {
-        setCopied(true);
-        setTimeout(() => setCopied(false), 1500);
-      });
-    },
-    [children],
-  );
-  return (
-    <div className={styles.copyableCode}>
-      <code>{children}</code>
-      <button
-        onClick={handleCopy}
-        className={styles.copyableCodeBtn}
-        title={copied ? "Copied!" : "Copy to clipboard"}
-        aria-label={copied ? "Copied!" : `Copy ${children}`}
-      >
-        {copied ? "✓" : "⎘"}
-      </button>
-    </div>
-  );
-}
 
 interface StreamInfo {
   label: string;
@@ -136,12 +109,12 @@ function StreamList({
           </div>
           {preferNvidia ? (
             entry.nvidiaCommand ? (
-              <CopyableCode>{entry.nvidiaCommand}</CopyableCode>
+                          <CodeBlock language="bash">{entry.nvidiaCommand}</CodeBlock>
             ) : (
               <span className={styles.emptyText}>No Nvidia variant for this tag.</span>
             )
           ) : (
-            <CopyableCode>{entry.command}</CopyableCode>
+                        <CodeBlock language="bash">{entry.command}</CodeBlock>
           )}
         </li>
       ))}
@@ -387,7 +360,7 @@ export default function ImagesCatalogComponent(): React.JSX.Element {
                               <strong>NVIDIA</strong> {entry.versions?.nvidia || "Unknown"}
                             </span>
                           </div>
-                          <CopyableCode>{entry.nvidiaCommand}</CopyableCode>
+              <CodeBlock language="bash">{entry.nvidiaCommand}</CodeBlock>
                         </>
                       ) : (
                         <p className={styles.emptyText}>No Nvidia variant published for this stream tag.</p>
@@ -407,7 +380,7 @@ export default function ImagesCatalogComponent(): React.JSX.Element {
                             </span>
                           )}
                         </div>
-                        <CopyableCode>{entry.command}</CopyableCode>
+            <CodeBlock language="bash">{entry.command}</CodeBlock>
                       </>
                     )}
                   </TabItem>
@@ -452,7 +425,7 @@ export default function ImagesCatalogComponent(): React.JSX.Element {
                   </Link>
                   .
                 </p>
-                {product.security?.verifyCommand && <CopyableCode>{product.security.verifyCommand}</CopyableCode>}
+                {product.security?.verifyCommand && <CodeBlock language="bash">{product.security.verifyCommand}</CodeBlock>}
               </TabItem>
               <TabItem value="verify-provenance">
                 <p className={styles.tabCopy}>
@@ -463,7 +436,7 @@ export default function ImagesCatalogComponent(): React.JSX.Element {
                   </Link>
                   .
                 </p>
-                {product.security?.attestCommand && <CopyableCode>{product.security.attestCommand}</CopyableCode>}
+                {product.security?.attestCommand && <CodeBlock language="bash">{product.security.attestCommand}</CodeBlock>}
                 {product.security?.attestCommand && product.security.hasAttestation === false && (
                   <p className={styles.tabCopy}>
                     Note: attestations are not yet published for this image. The command is provided for when they are.
@@ -479,7 +452,7 @@ export default function ImagesCatalogComponent(): React.JSX.Element {
                   </Link>
                   .
                 </p>
-                {product.security?.sbomCommand && <CopyableCode>{product.security.sbomCommand}</CopyableCode>}
+                {product.security?.sbomCommand && <CodeBlock language="bash">{product.security.sbomCommand}</CodeBlock>}
               </TabItem>
             </Tabs>
           </section>

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -64,3 +64,21 @@ a[rel*="noopener"]::after {
 .docs-doc-id-images .theme-doc-markdown {
   max-width: none;
 }
+
+/* ── Copy button consistency ──────────────────────────────────────────────── */
+/*
+ * Docusaurus renders the copy button as position:absolute inside the <pre>
+ * container. Without extra right padding, code text on the last line slides
+ * directly underneath it.  Reserve ~3rem so that never happens.
+ */
+.theme-code-block pre {
+  padding-right: 3.5rem !important;
+}
+
+/*
+ * Reveal the copy button on keyboard focus as well as mouse hover so it is
+ * accessible to keyboard and screen-reader users.
+ */
+[class*="buttonGroup"] button:focus-visible {
+  opacity: 1 !important;
+}

--- a/static/data/sbom-attestations.json
+++ b/static/data/sbom-attestations.json
@@ -1,0 +1,1 @@
+{ "generatedAt": null, "streams": {} }


### PR DESCRIPTION
## Summary

- Add holographic/foil hover effects to driver version bump cards (gold=major, silver=minor, green=NVIDIA)
- Add Mesa and GNOME version cards with foil effects alongside driver version cards
- Refactor ImagesCatalog to use Docusaurus \`CodeBlock\` instead of custom \`CopyableCode\`
- Fix copy/paste widget consistency across stream tabs
- Show minor version bump on latest card; hide null HWE Kernel field

## Commits

- \`8531dde\` fix(ui): make copy/paste widgets globally consistent
- \`e8b6df5\` fix(images): replace bare \`<code>\` with CopyableCode in stream tabs
- \`8df666b\` refactor(images): replace custom CopyableCode with Docusaurus CodeBlock
- \`2e64317\` style(driver-versions): gold/silver foil on major/minor bump cards
- \`1117ccb\` style(driver-versions): green foil for NVIDIA bumps, fix pill legibility
- \`c497498\` feat(components): add Mesa/GNOME version cards with foil effects
- \`3a30902\` fix(components): show minor bump on latest card, hide null HWE Kernel

_Fork-internal CI PR. Upstream PR to be submitted manually to projectbluefin/documentation after CI passes._

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>