### PR TITLE
docs(downloads): add weekly lts-hwe testing download table

### DIFF
--- a/docs/downloads-testing.md
+++ b/docs/downloads-testing.md
@@ -36,6 +36,15 @@ The long term support experience.\
 | Bluefin LTS (Hardware Enablement) | AMD/Intel     | [📥 bluefin-lts-hwe-x86_64.iso](https://projectbluefin.dev/bluefin-lts-hwe-x86_64.iso)   | [🧲 Torrent](https://projectbluefin.dev/bluefin-lts-hwe-x86_64.iso.torrent)    | [🔐 Verify](https://projectbluefin.dev/bluefin-lts-hwe-x86_64.iso-CHECKSUM)  |
 | Bluefin LTS (Hardware Enablement) | ARM (aarch64) | [📥 bluefin-lts-hwe-aarch64.iso](https://projectbluefin.dev/bluefin-lts-hwe-aarch64.iso) | [🧲 Torrent](https://projectbluefin.dev/bluefin-lts-hwe-aarch64.iso.torrent) | [🔐 Verify](https://projectbluefin.dev/bluefin-lts-hwe-aarch64.iso-CHECKSUM) |
 
+### LTS-HWE Testing (Weekly)
+
+These are weekly testing ISOs for the hardware-enablement branch.
+
+| Version                                   | GPU           | Download                                                                                                 | Torrent                                                                                                       | Checksum                                                                                                     |
+| ----------------------------------------- | ------------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| Bluefin LTS (Hardware Enablement Testing) | AMD/Intel     | [📥 bluefin-lts-hwe-testing-x86_64.iso](https://projectbluefin.dev/bluefin-lts-hwe-testing-x86_64.iso)   | [🧲 Torrent](https://projectbluefin.dev/bluefin-lts-hwe-testing-x86_64.iso.torrent)                           | [🔐 Verify](https://projectbluefin.dev/bluefin-lts-hwe-testing-x86_64.iso-CHECKSUM)                          |
+| Bluefin LTS (Hardware Enablement Testing) | ARM (aarch64) | [📥 bluefin-lts-hwe-testing-aarch64.iso](https://projectbluefin.dev/bluefin-lts-hwe-testing-aarch64.iso) | [🧲 Torrent](https://projectbluefin.dev/bluefin-lts-hwe-testing-aarch64.iso.torrent)                         | [🔐 Verify](https://projectbluefin.dev/bluefin-lts-hwe-testing-aarch64.iso-CHECKSUM)                         |
+
 ## Bluefin GDX
 
 The AI workstation with Nvidia and CUDA.\


### PR DESCRIPTION
## Summary

- Add weekly LTS-HWE testing ISO downloads table to downloads-testing page
- Matches table format used across the page, including torrent and checksum links for x86_64 and aarch64

_Fork-internal CI PR. Upstream PR to be submitted manually after CI passes._

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>