### PR TITLE
fix(ci,images,changelogs): least-privilege tokens, correct stream attestation, remove download counts

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Fetch data
         env:
-          GITHUB_TOKEN: ${{ secrets.PROJECT_READ_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           # Always re-fetch driver versions on every build so GNOME/kernel/mesa
           # versions stay current. The data is small (GitHub API call) and the
           # script's internal 168h TTL would otherwise serve stale cached data.
@@ -69,6 +69,13 @@ jobs:
           # without this the cache check sees a fresh mtime and skips the fetch.
           FIREHOSE_CACHE_HOURS: "0"
         run: npm run fetch-data
+
+      - name: Fetch board data
+        env:
+          # fetch-board-data.js requires project:read scope; only this step
+          # receives the elevated PAT — all other fetch scripts use github.token.
+          GITHUB_TOKEN: ${{ secrets.PROJECT_READ_TOKEN }}
+        run: node scripts/fetch-board-data.js
 
       - name: Run TypeScript validation
         run: npm run typecheck

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "generate-report": "node scripts/generate-report.mjs",
     "fetch-sbom": "node scripts/fetch-github-sbom.js",
     "fetch-firehose": "node scripts/fetch-firehose.js",
-    "fetch-data": "npm run fetch-feeds && npm run fetch-playlists && npm run fetch-github-profiles && npm run fetch-github-repos && npm run fetch-github-driver-versions && npm run fetch-github-images && npm run fetch-contributors && npm run fetch-board-data && npm run fetch-firehose"
+    "fetch-data": "npm run fetch-feeds && npm run fetch-playlists && npm run fetch-github-profiles && npm run fetch-github-repos && npm run fetch-github-driver-versions && npm run fetch-github-images && npm run fetch-contributors && npm run fetch-firehose"
   },
   "dependencies": {
     "@1password/docusaurus-plugin-stored-data": "^1.0.0",

--- a/scripts/fetch-github-images.js
+++ b/scripts/fetch-github-images.js
@@ -174,11 +174,6 @@ function normalizeTestingTag(raw) {
     .replace(/(^[.-]+|[.-]+$)/g, "");
 }
 
-function formatDownloads(value) {
-  if (typeof value !== "number") return "Unavailable";
-  return new Intl.NumberFormat("en-US").format(value);
-}
-
 function parseFeedVersion(feedItem, labels) {
   if (!feedItem || !feedItem.content) return null;
   for (const label of labels) {
@@ -230,33 +225,6 @@ function latestFeedItem(feeds, source) {
   });
 
   return match || null;
-}
-
-async function fetchText(url) {
-  const headers = {
-    "User-Agent": "BluefinDocsImages/1.0",
-    Accept: "application/vnd.github+json",
-  };
-  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
-  if (token) headers.Authorization = `Bearer ${token}`;
-
-  const response = await fetch(url, { headers });
-  if (!response.ok) {
-    throw new Error(`${response.status} ${response.statusText}`);
-  }
-
-  return response.text();
-}
-
-async function fetchDownloads(org, pkg) {
-  const url = `https://github.com/orgs/${org}/packages/container/package/${pkg}`;
-  const html = await fetchText(url);
-  const match = html.match(
-    /Total downloads<\/span>\s*<h3[^>]*title="([\d,]+)"/i,
-  );
-  if (!match) return null;
-  const value = Number.parseInt(match[1].replace(/,/g, ""), 10);
-  return Number.isNaN(value) ? null : value;
 }
 
 async function listTags(imageRef) {
@@ -536,7 +504,6 @@ async function buildProduct(spec, feeds, cachedById, ageHours, sbomCache) {
   if (!shouldRefresh && existing) {
     return {
       ...existing,
-      downloads: { ...existing.downloads, source: "cache" },
       metadataSource: "cache",
     };
   }
@@ -544,18 +511,6 @@ async function buildProduct(spec, feeds, cachedById, ageHours, sbomCache) {
   const imageRef = `ghcr.io/${spec.org}/${spec.package}`;
 
   const versions = await fetchPackageVersions(spec.org, spec.package);
-
-  let downloadsTotal = null;
-  let downloadSource = "unavailable";
-  try {
-    downloadsTotal = await fetchDownloads(spec.org, spec.package);
-    downloadSource = downloadsTotal === null ? "unavailable" : "live";
-  } catch {
-    if (typeof existing?.downloads?.total === "number") {
-      downloadsTotal = existing.downloads.total;
-      downloadSource = "cache";
-    }
-  }
 
   let tags = [];
   try {
@@ -672,11 +627,6 @@ async function buildProduct(spec, feeds, cachedById, ageHours, sbomCache) {
     imageRef,
     packagePageUrl: `https://github.com/orgs/${spec.org}/packages/container/package/${spec.package}`,
     isoSectionLink: spec.isoSectionLink || null,
-    downloads: {
-      total: downloadsTotal,
-      display: formatDownloads(downloadsTotal),
-      source: downloadSource,
-    },
     streams,
     testingStreams,
     metadata,
@@ -735,14 +685,7 @@ async function main() {
     products.push(product);
   }
 
-  products.sort((a, b) => {
-    const aScore =
-      typeof a.downloads.total === "number" ? a.downloads.total : -1;
-    const bScore =
-      typeof b.downloads.total === "number" ? b.downloads.total : -1;
-    if (aScore !== bScore) return bScore - aScore;
-    return a.name.localeCompare(b.name);
-  });
+  products.sort((a, b) => a.name.localeCompare(b.name));
 
   const output = {
     generatedAt: new Date().toISOString(),

--- a/src/components/FeedItems.tsx
+++ b/src/components/FeedItems.tsx
@@ -319,7 +319,7 @@ const extractReleaseTag = (title: string): string | null => {
   return normalized;
 };
 
-const getSupplyChainLinks = (title: string): SupplyChainLinks => {
+const getSupplyChainLinks = (title: string, feedId?: string): SupplyChainLinks => {
   const releaseTag = extractReleaseTag(title);
 
   if (!releaseTag) {
@@ -332,11 +332,25 @@ const getSupplyChainLinks = (title: string): SupplyChainLinks => {
 
   // Look up attestation state from the SBOM cache.
   // Cache keys match releaseTag format: stable-YYYYMMDD, latest-YYYYMMDD, lts-YYYYMMDD, etc.
+  //
+  // lts-YYYYMMDD keys appear in multiple streams (bluefin-lts, bluefin-dx-lts, bluefin-gdx-lts).
+  // Use feedId to prefer the correct stream family before falling back to any match.
+  const isLtsFeed = feedId === "bluefinLtsReleases";
+
   let attestationVerified: boolean | null = null;
   let attestationPresent: boolean | null = null;
   const cache = sbomAttestationsData as unknown as SbomAttestationsData;
   if (cache?.streams) {
-    for (const stream of Object.values(cache.streams)) {
+    const streamEntries = Object.entries(cache.streams);
+
+    // First pass: only streams that match the feed's LTS/non-LTS family.
+    const preferred = streamEntries.filter(([key]) =>
+      isLtsFeed ? key.includes("lts") : !key.includes("lts"),
+    );
+
+    const searchOrder = preferred.length > 0 ? preferred : streamEntries;
+
+    for (const [, stream] of searchOrder) {
       const entry = stream.releases?.[releaseTag];
       if (entry) {
         attestationVerified = entry.attestation.verified ?? null;
@@ -742,7 +756,7 @@ const CombinedFeedItems: React.FC<CombinedFeedItemsProps> = ({
             isRelease && itemDescription ? extractCommits(itemDescription) : [];
           const supplyChainHighlights = extractSupplyChainHighlights(commits);
           const displayTitle = formatReleaseTitle(item.title, item._feedId);
-          const supplyChainLinks = getSupplyChainLinks(displayTitle);
+          const supplyChainLinks = getSupplyChainLinks(displayTitle, item._feedId);
           const majorVersionBumps =
             isRelease && itemDescription
               ? extractMajorVersionBumps(itemDescription)

--- a/src/components/ImagesCatalog.tsx
+++ b/src/components/ImagesCatalog.tsx
@@ -28,10 +28,6 @@ interface Product {
   artwork: "bluefin" | "achillobator" | "dakotaraptor";
   packagePageUrl: string;
   isoSectionLink?: string | null;
-  downloads: {
-    display: string;
-    source: "live" | "cache" | "unavailable";
-  };
   streams: StreamInfo[];
   testingStreams: StreamInfo[];
   metadata: {
@@ -276,12 +272,6 @@ export default function ImagesCatalogComponent(): React.JSX.Element {
           <p className={styles.summary}>{product.summary}</p>
 
           <div className={styles.statsRow}>
-            <span className={styles.statChip}>
-              <strong>Pulls:</strong> {product.downloads.display}
-            </span>
-            <span className={sourceClass(product.downloads.source)}>
-              {sourceText(product.downloads.source, "Downloads")}
-            </span>
             <span className={sourceClass(product.metadataSource)}>
               {sourceText(product.metadataSource, "Metadata")}
             </span>


### PR DESCRIPTION
## Summary

- **#43**: `pages.yml` now passes `github.token` to all fetch scripts; only `fetch-board-data.js` gets `PROJECT_READ_TOKEN` in a dedicated step. Also removes `fetch-board-data` from the `fetch-data` npm script so it only runs with the elevated token.
- **#54**: `FeedItems.tsx` passes `feedId` into `getSupplyChainLinks()` and filters SBOM attestation streams to the correct LTS/non-LTS family, preventing DX LTS and GDX changelog cards from showing attestation status from the wrong stream.
- **#41**: Remove `fetchDownloads()` HTML scraping, `fetchText()`, the `downloads` field from `images.json`, and the Pulls stat chip from the images page. The data was cosmetic and there is no public API for container download counts without a PAT.

## Validation

- `npm run typecheck`: 0 errors
- `npm run lint`: 0 errors, 66 warnings (unchanged baseline)

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>