### PR TITLE
fix(sbom): enforce sbom-only version sources across docs surfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /static/feeds/*.json
 /static/data/*.json
 !/static/data/sbom-attestations.json
+!/static/data/sbom-attestations-frontend.json
 !/static/data/firehose-apps.json
 
 # Misc

--- a/scripts/fetch-github-driver-versions.js
+++ b/scripts/fetch-github-driver-versions.js
@@ -25,6 +25,11 @@ const CACHE_MAX_AGE_HOURS = Number(
 const HISTORY_DAYS = Number(process.env.DRIVER_VERSIONS_HISTORY_DAYS || 90);
 const FORCE_REFRESH = process.argv.includes("--force");
 
+const RELEASE_URL_BY_STREAM = {
+  "bluefin-stable": "https://github.com/ublue-os/bluefin/releases",
+  "bluefin-lts": "https://github.com/ublue-os/bluefin-lts/releases",
+};
+
 function readJsonIfExists(filePath, fallback) {
   if (!fs.existsSync(filePath)) return fallback;
   try {
@@ -109,23 +114,6 @@ function splitVersion(raw) {
   return parts.length ? parts[parts.length - 1] : String(raw).trim();
 }
 
-function extractVersion(content, labels) {
-  if (!content) return null;
-
-  for (const label of labels) {
-    const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    const regex = new RegExp(
-      `<td><strong>${escaped}<\\/strong><\\/td>\\s*<td>([^<]+)<\\/td>`,
-      "i",
-    );
-    const match = content.match(regex);
-    if (!match || !match[1]) continue;
-    return splitVersion(match[1]);
-  }
-
-  return null;
-}
-
 function extractVersionFromMarkdown(content, labels) {
   if (!content) return null;
 
@@ -173,11 +161,11 @@ function buildRow(item, streamId) {
     releaseUrl: item?.link || null,
     publishedAt: parseDate(item?.pubDate || item?.updated || null),
     versions: {
-      kernel: extractVersion(content, ["Kernel"]),
-      hweKernel: extractVersion(content, ["HWE Kernel"]),
-      mesa: extractVersion(content, ["Mesa"]),
-      nvidia: extractVersion(content, ["Nvidia", "NVIDIA"]),
-      gnome: extractVersion(content, ["Gnome", "GNOME"]),
+      kernel: null,
+      hweKernel: null,
+      mesa: null,
+      nvidia: extractVersionFromMarkdown(content, ["Nvidia", "NVIDIA"]),
+      gnome: null,
     },
   };
 }
@@ -193,33 +181,90 @@ function buildRowFromApiRelease(release, streamId) {
       release?.published_at || release?.created_at || null,
     ),
     versions: {
-      kernel: extractVersionFromMarkdown(body, ["Kernel"]),
-      hweKernel: extractVersionFromMarkdown(body, ["HWE Kernel"]),
-      mesa: extractVersionFromMarkdown(body, ["Mesa"]),
+      kernel: null,
+      hweKernel: null,
+      mesa: null,
       nvidia: extractVersionFromMarkdown(body, ["Nvidia", "NVIDIA"]),
-      gnome: extractVersionFromMarkdown(body, ["Gnome", "GNOME"]),
+      gnome: null,
     },
   };
 }
 
-function pickBluefinStableItems(feed) {
-  const items = Array.isArray(feed?.items) ? feed.items : [];
-  return items.filter((item) =>
-    String(item?.title || "")
-      .toLowerCase()
-      .startsWith("stable-"),
-  );
+function rowFromSbomRelease(streamId, cacheKey, releaseEntry, nvidiaVersion) {
+  const pkg = releaseEntry?.packageVersions || {};
+  const datePart = String(cacheKey || "").match(/(\d{8})$/)?.[1] || null;
+  let publishedAt = null;
+  if (datePart) {
+    publishedAt = datePart.replace(/(\d{4})(\d{2})(\d{2})/, "$1-$2-$3T00:00:00.000Z");
+  }
+
+  return {
+    stream: streamId,
+    tag: releaseEntry?.tag || cacheKey,
+    title: releaseEntry?.tag || cacheKey,
+    releaseUrl: RELEASE_URL_BY_STREAM[streamId] || null,
+    publishedAt,
+    versions: {
+      kernel: pkg.kernel || null,
+      hweKernel: null,
+      mesa: pkg.mesa || null,
+      nvidia: nvidiaVersion || null,
+      gnome: pkg.gnome || null,
+    },
+  };
 }
 
-function pickLtsItems(feed) {
-  const items = Array.isArray(feed?.items) ? feed.items : [];
-  return items.filter((item) => {
-    const link = String(item?.link || "").toLowerCase();
-    if (link.includes("/releases/tag/lts.")) return true;
-    return String(item?.title || "")
-      .toLowerCase()
-      .includes(" lts:");
-  });
+function buildStreamFromSbom(
+  streamId,
+  name,
+  subtitle,
+  command,
+  sbomCache,
+  nvidiaByTag,
+) {
+  const stream = sbomCache?.streams?.[streamId];
+  const releases = stream?.releases || {};
+  const cutoff = Date.now() - HISTORY_DAYS * 24 * 60 * 60 * 1000;
+
+  const history = Object.entries(releases)
+    .sort(([a], [b]) => b.localeCompare(a))
+    .map(([cacheKey, entry]) =>
+      rowFromSbomRelease(
+        streamId,
+        cacheKey,
+        entry,
+        nvidiaByTag?.[entry?.tag || cacheKey] || null,
+      ),
+    )
+    .filter((row) => {
+      const parsed = Date.parse(row.publishedAt || "");
+      if (Number.isNaN(parsed)) return false;
+      return parsed >= cutoff;
+    });
+
+  return {
+    id: streamId,
+    name,
+    subtitle,
+    command,
+    source: "sbom",
+    rowCount: history.length,
+    latest: history[0] || null,
+    history,
+  };
+}
+
+function buildNvidiaMap(releases) {
+  const map = {};
+  for (const release of releases || []) {
+    const tag = release?.tag_name;
+    if (!tag) continue;
+    map[tag] = extractVersionFromMarkdown(release?.body || "", [
+      "Nvidia",
+      "NVIDIA",
+    ]);
+  }
+  return map;
 }
 
 function buildStream(streamId, name, subtitle, command, feedItems, sbomCache) {
@@ -241,7 +286,7 @@ function buildStream(streamId, name, subtitle, command, feedItems, sbomCache) {
     name,
     subtitle,
     command,
-    source: "cache",
+    source: "release-fallback",
     rowCount: history.length,
     latest: history[0] || null,
     history,
@@ -307,7 +352,7 @@ function buildStreamFromApi(
     name,
     subtitle,
     command,
-    source: "github-api",
+    source: "release-fallback",
     rowCount: history.length,
     latest: history[0] || null,
     history,
@@ -324,13 +369,66 @@ async function main() {
   }
 
   const sbomCache = readJsonIfExists(SBOM_FILE, null);
-  if (sbomCache) {
+  const hasSbomData =
+    Boolean(sbomCache?.generatedAt) &&
+    Boolean(sbomCache?.streams) &&
+    Object.keys(sbomCache.streams).length > 0;
+
+  if (hasSbomData) {
     console.log("SBOM attestation cache loaded.");
-  } else {
-    console.log(
-      "SBOM attestation cache not found — kernel/mesa will fall back to release bodies.",
-    );
+    let stableNvidia = {};
+    let ltsNvidia = {};
+    try {
+      const [bluefinReleases, ltsReleases] = await Promise.all([
+        fetchReleases("ublue-os", "bluefin"),
+        fetchReleases("ublue-os", "bluefin-lts"),
+      ]);
+      stableNvidia = buildNvidiaMap(bluefinReleases);
+      ltsNvidia = buildNvidiaMap(ltsReleases);
+    } catch {
+      console.warn(
+        "Could not fetch release bodies for NVIDIA fallback; continuing with SBOM-only values.",
+      );
+    }
+
+    const streams = [
+      buildStreamFromSbom(
+        "bluefin-stable",
+        "Bluefin",
+        "Current stable stream from ublue-os/bluefin.",
+        "sudo bootc switch ghcr.io/ublue-os/bluefin:stable --enforce-container-sigpolicy",
+        sbomCache,
+        stableNvidia,
+      ),
+      buildStreamFromSbom(
+        "bluefin-lts",
+        "Bluefin LTS",
+        "Long-term support stream from ublue-os/bluefin-lts.",
+        "sudo bootc switch ghcr.io/ublue-os/bluefin:lts --enforce-container-sigpolicy",
+        sbomCache,
+        ltsNvidia,
+      ),
+    ];
+
+    const output = {
+      generatedAt: new Date().toISOString(),
+      cacheHours: CACHE_MAX_AGE_HOURS,
+      historyDays: HISTORY_DAYS,
+      streams,
+    };
+
+    if (!fs.existsSync(OUTPUT_DIR)) {
+      fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+    }
+
+    fs.writeFileSync(OUTPUT_FILE, JSON.stringify(output, null, 2), "utf-8");
+    console.log(`Driver versions data saved to ${OUTPUT_FILE} (SBOM primary)`);
+    return;
   }
+
+  console.warn(
+    "SBOM attestation cache not found — using release fallback (NVIDIA workaround path).",
+  );
 
   return Promise.all([
     fetchReleases("ublue-os", "bluefin"),
@@ -345,7 +443,7 @@ async function main() {
           "sudo bootc switch ghcr.io/ublue-os/bluefin:stable --enforce-container-sigpolicy",
           bluefinReleases,
           "stable-",
-          sbomCache,
+          null,
         ),
         buildStreamFromApi(
           "bluefin-lts",
@@ -354,7 +452,7 @@ async function main() {
           "sudo bootc switch ghcr.io/ublue-os/bluefin:lts --enforce-container-sigpolicy",
           ltsReleases,
           "lts.",
-          sbomCache,
+          null,
         ),
       ];
 
@@ -385,16 +483,16 @@ async function main() {
           "Bluefin",
           "Current stable stream from ublue-os/bluefin.",
           "sudo bootc switch ghcr.io/ublue-os/bluefin:stable --enforce-container-sigpolicy",
-          pickBluefinStableItems(bluefinFeed),
-          sbomCache,
+          bluefinFeed.items || [],
+          null,
         ),
         buildStream(
           "bluefin-lts",
           "Bluefin LTS",
           "Long-term support stream from ublue-os/bluefin-lts.",
           "sudo bootc switch ghcr.io/ublue-os/bluefin:lts --enforce-container-sigpolicy",
-          pickLtsItems(ltsFeed),
-          sbomCache,
+          ltsFeed.items || [],
+          null,
         ),
       ];
 
@@ -416,7 +514,15 @@ async function main() {
     });
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  lookupSbomVersionsForTag,
+  rowFromSbomRelease,
+  buildStreamFromSbom,
+};

--- a/scripts/fetch-github-driver-versions.js
+++ b/scripts/fetch-github-driver-versions.js
@@ -30,6 +30,11 @@ const RELEASE_URL_BY_STREAM = {
   "bluefin-lts": "https://github.com/ublue-os/bluefin-lts/releases",
 };
 
+const RELEASE_REPO_BY_STREAM = {
+  "bluefin-stable": "ublue-os/bluefin",
+  "bluefin-lts": "ublue-os/bluefin-lts",
+};
+
 function readJsonIfExists(filePath, fallback) {
   if (!fs.existsSync(filePath)) return fallback;
   try {
@@ -202,7 +207,13 @@ function rowFromSbomRelease(streamId, cacheKey, releaseEntry, nvidiaVersion) {
     stream: streamId,
     tag: releaseEntry?.tag || cacheKey,
     title: releaseEntry?.tag || cacheKey,
-    releaseUrl: RELEASE_URL_BY_STREAM[streamId] || null,
+    releaseUrl: (() => {
+      const tag = releaseEntry?.tag || cacheKey;
+      const repo = RELEASE_REPO_BY_STREAM[streamId];
+      return repo && tag
+        ? `https://github.com/${repo}/releases/tag/${tag}`
+        : RELEASE_URL_BY_STREAM[streamId] || null;
+    })(),
     publishedAt,
     versions: {
       kernel: pkg.kernel || null,
@@ -254,15 +265,26 @@ function buildStreamFromSbom(
   };
 }
 
+function normalizeReleaseTag(tag) {
+  // GitHub LTS release tags use dots (lts.YYYYMMDD) but SBOM cache keys use
+  // hyphens (lts-YYYYMMDD). Normalize so NVIDIA lookups match SBOM entries.
+  return typeof tag === "string" ? tag.replace(/^lts\./, "lts-") : tag;
+}
+
 function buildNvidiaMap(releases) {
   const map = {};
   for (const release of releases || []) {
     const tag = release?.tag_name;
     if (!tag) continue;
-    map[tag] = extractVersionFromMarkdown(release?.body || "", [
+    const normalizedTag = normalizeReleaseTag(tag);
+    const version = extractVersionFromMarkdown(release?.body || "", [
       "Nvidia",
       "NVIDIA",
     ]);
+    map[normalizedTag] = version;
+    // Also key by raw tag so stable-YYYYMMDD lookups (no normalization needed)
+    // still resolve correctly without a second pass.
+    if (normalizedTag !== tag) map[tag] = version;
   }
   return map;
 }
@@ -294,24 +316,34 @@ function buildStream(streamId, name, subtitle, command, feedItems, sbomCache) {
 }
 
 async function fetchReleases(owner, repo) {
-  const url = `https://api.github.com/repos/${owner}/${repo}/releases?per_page=100`;
-  const response = await fetch(url, {
-    headers: {
-      Accept: "application/vnd.github+json",
-      "User-Agent": "bluefin-docs-driver-versions",
-      ...(process.env.GITHUB_TOKEN
-        ? { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` }
-        : {}),
-    },
-  });
+  const releases = [];
+  let url = `https://api.github.com/repos/${owner}/${repo}/releases?per_page=100`;
+  const headers = {
+    Accept: "application/vnd.github+json",
+    "User-Agent": "bluefin-docs-driver-versions",
+    ...(process.env.GITHUB_TOKEN
+      ? { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` }
+      : {}),
+  };
 
-  if (!response.ok) {
-    throw new Error(
-      `GitHub releases API failed for ${owner}/${repo}: ${response.status}`,
-    );
+  while (url) {
+    const response = await fetch(url, { headers });
+
+    if (!response.ok) {
+      throw new Error(
+        `GitHub releases API failed for ${owner}/${repo}: ${response.status}`,
+      );
+    }
+
+    const page = await response.json();
+    releases.push(...page);
+
+    const link = response.headers.get("link");
+    const next = link?.match(/<([^>]+)>;\s*rel="next"/)?.[1] ?? null;
+    url = next;
   }
 
-  return response.json();
+  return releases;
 }
 
 function buildStreamFromApi(

--- a/scripts/fetch-github-driver-versions.test.js
+++ b/scripts/fetch-github-driver-versions.test.js
@@ -1,0 +1,85 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  lookupSbomVersionsForTag,
+  rowFromSbomRelease,
+  buildStreamFromSbom,
+} = require("./fetch-github-driver-versions.js");
+
+test("lookupSbomVersionsForTag returns packageVersions by stream and key", () => {
+  const cache = {
+    streams: {
+      "bluefin-stable": {
+        releases: {
+          "stable-20260331": {
+            packageVersions: { kernel: "6.18.13-200", mesa: "25.3.6-6" },
+          },
+        },
+      },
+    },
+  };
+
+  const result = lookupSbomVersionsForTag(
+    cache,
+    "bluefin-stable",
+    "stable-20260331",
+  );
+  assert.deepEqual(result, { kernel: "6.18.13-200", mesa: "25.3.6-6" });
+});
+
+test("rowFromSbomRelease builds kernel/mesa/gnome from SBOM only", () => {
+  const row = rowFromSbomRelease(
+    "bluefin-stable",
+    "stable-20260331",
+    {
+      tag: "stable-20260331",
+      packageVersions: {
+        kernel: "6.18.13-200",
+        mesa: "25.3.6-6",
+        gnome: "49.5-1",
+      },
+    },
+    "595.58.03-1",
+  );
+
+  assert.equal(row.versions.kernel, "6.18.13-200");
+  assert.equal(row.versions.mesa, "25.3.6-6");
+  assert.equal(row.versions.gnome, "49.5-1");
+  assert.equal(row.versions.nvidia, "595.58.03-1");
+});
+
+test("buildStreamFromSbom sorts newest-first and marks source sbom", () => {
+  const cache = {
+    streams: {
+      "bluefin-stable": {
+        releases: {
+          "stable-20260324": {
+            tag: "stable-20260324",
+            packageVersions: { kernel: "6.18.12-200", mesa: "25.3.6-4", gnome: "49.5-1" },
+          },
+          "stable-20260331": {
+            tag: "stable-20260331",
+            packageVersions: { kernel: "6.18.13-200", mesa: "25.3.6-6", gnome: "49.5-1" },
+          },
+        },
+      },
+    },
+  };
+
+  const stream = buildStreamFromSbom(
+    "bluefin-stable",
+    "Bluefin",
+    "Current stable stream.",
+    "sudo bootc switch ghcr.io/ublue-os/bluefin:stable --enforce-container-sigpolicy",
+    cache,
+    {
+      "stable-20260331": "595.58.03-1",
+      "stable-20260324": "595.45.04-4",
+    },
+  );
+
+  assert.equal(stream.source, "sbom");
+  assert.equal(stream.latest?.tag, "stable-20260331");
+  assert.equal(stream.latest?.versions.kernel, "6.18.13-200");
+});

--- a/scripts/fetch-github-images.js
+++ b/scripts/fetch-github-images.js
@@ -195,18 +195,9 @@ function parseFeedVersion(feedItem, labels) {
   return null;
 }
 
-function parseFedoraFromFeedItem(feedItem) {
-  if (!feedItem?.title) return null;
-  const match = feedItem.title.match(/\(F(\d+)[^)]*\)/i);
-  if (!match || !match[1]) return null;
-  return `F${match[1]}`;
-}
-
-function parseFedoraFromImageVersion(imageVersion) {
-  if (!imageVersion) return null;
-  const match = String(imageVersion).match(/^(\d{2})\./);
-  if (!match || !match[1]) return null;
-  return `F${match[1]}`;
+function sbomVersionsForStream(sbomCache, sbomStreamId) {
+  if (!sbomCache || !sbomStreamId) return null;
+  return lookupSbomVersions(sbomCache, sbomStreamId);
 }
 
 function latestFeedItem(feeds, source) {
@@ -336,6 +327,7 @@ async function buildStreamVersionInfo(
   feeds,
   sbomCache,
 ) {
+  const sbomVersions = sbomVersionsForStream(sbomCache, spec.sbomStreamId);
   const feedKey = streamTag === "lts" ? "lts" : streamTag;
   const feedSource = spec.versionSource
     ? { feed: spec.versionSource.feed, stream: feedKey }
@@ -343,45 +335,20 @@ async function buildStreamVersionInfo(
   const feedItem = latestFeedItem(feeds, feedSource);
 
   const versions = {
-    gnome: parseFeedVersion(feedItem, ["GNOME", "Gnome"]),
-    kernel: parseFeedVersion(feedItem, ["Kernel"]),
+    gnome: sbomVersions?.gnome || null,
+    kernel: sbomVersions?.kernel || null,
     nvidia: parseFeedVersion(feedItem, ["Nvidia"]),
-    fedora: null,
+    fedora: sbomVersions?.fedora || null,
   };
 
-  let imageVersion = null;
-  try {
-    const inspected = await inspectImage(imageRef, streamTag);
-    imageVersion =
-      inspected?.Labels?.["org.opencontainers.image.version"] || null;
-  } catch {
-    imageVersion = null;
-  }
-
-  if (spec.name.includes("LTS") || spec.name.includes("GDX")) {
-    versions.fedora = "10";
-  } else {
-    versions.fedora =
-      parseFedoraFromFeedItem(feedItem) ||
-      parseFedoraFromImageVersion(imageVersion);
-  }
+  // SBOM-only policy: fedora version is sourced from SBOM packageVersions.
+  // Do not infer from release bodies or image labels.
 
   if (spec.versionOverrides) {
     versions.gnome = spec.versionOverrides.gnome ?? versions.gnome;
     versions.kernel = spec.versionOverrides.kernel ?? versions.kernel;
     versions.nvidia = spec.versionOverrides.nvidia ?? versions.nvidia;
     versions.fedora = spec.versionOverrides.fedora ?? versions.fedora;
-  }
-
-  // Overlay SBOM-sourced versions for kernel, gnome, and fedora.
-  // NVIDIA is intentionally excluded — it is not in the SBOM (akmod, built outside image).
-  if (sbomCache && spec.sbomStreamId) {
-    const sbomVersions = lookupSbomVersions(sbomCache, spec.sbomStreamId);
-    if (sbomVersions) {
-      if (sbomVersions.kernel) versions.kernel = sbomVersions.kernel;
-      if (sbomVersions.gnome) versions.gnome = sbomVersions.gnome;
-      if (sbomVersions.fedora) versions.fedora = sbomVersions.fedora;
-    }
   }
 
   return versions;
@@ -591,22 +558,13 @@ async function buildProduct(spec, feeds, cachedById, ageHours, sbomCache) {
   }
 
   const feedItem = latestFeedItem(feeds, spec.versionSource);
+  const sbomVersions = sbomVersionsForStream(sbomCache, spec.sbomStreamId);
   const versionsFromFeed = {
-    gnome: parseFeedVersion(feedItem, ["GNOME", "Gnome"]),
-    kernel: parseFeedVersion(feedItem, ["Kernel"]),
+    gnome: sbomVersions?.gnome || null,
+    kernel: sbomVersions?.kernel || null,
     nvidia: parseFeedVersion(feedItem, ["Nvidia"]),
     release: releaseInfoFromFeedItem(feedItem),
   };
-
-  // Overlay SBOM-sourced versions for kernel and gnome on the top-level versions object.
-  // NVIDIA is intentionally excluded — it is not in the SBOM.
-  if (sbomCache && spec.sbomStreamId) {
-    const sbomVersions = lookupSbomVersions(sbomCache, spec.sbomStreamId);
-    if (sbomVersions) {
-      if (sbomVersions.kernel) versionsFromFeed.kernel = sbomVersions.kernel;
-      if (sbomVersions.gnome) versionsFromFeed.gnome = sbomVersions.gnome;
-    }
-  }
 
   if (metadata && !metadata.digestLink && versionsFromFeed.release?.assetsUrl) {
     metadata.digestLink = versionsFromFeed.release.assetsUrl;

--- a/scripts/fetch-github-sbom.js
+++ b/scripts/fetch-github-sbom.js
@@ -59,6 +59,20 @@ const OUTPUT_FILE = path.join(
   "sbom-attestations.json",
 );
 
+/**
+ * Frontend-facing slim copy of the SBOM cache.
+ * Identical structure but with `allPackages` stripped from every release —
+ * keeping only `packageVersions` and `attestation`. This prevents the full
+ * RPM inventory (hundreds of entries per release) from bloating the JS bundle.
+ */
+const FRONTEND_OUTPUT_FILE = path.join(
+  __dirname,
+  "..",
+  "static",
+  "data",
+  "sbom-attestations-frontend.json",
+);
+
 // How many calendar days of releases to scan per stream.
 const LOOKBACK_DAYS = Number(process.env.SBOM_LOOKBACK_DAYS || 90);
 
@@ -1020,6 +1034,23 @@ async function main() {
   fs.writeFileSync(tmpFile, JSON.stringify(output, null, 2), "utf-8");
   fs.renameSync(tmpFile, OUTPUT_FILE);
   console.log(`\nSBOM attestation cache written to ${OUTPUT_FILE}`);
+
+  // Write slim frontend copy — strips allPackages from every release so the
+  // JS bundle only includes packageVersions + attestation (not full RPM lists).
+  const frontendStreams = {};
+  for (const [streamId, stream] of Object.entries(streams)) {
+    const slimReleases = {};
+    for (const [key, entry] of Object.entries(stream.releases || {})) {
+      const { allPackages: _dropped, ...rest } = entry;
+      slimReleases[key] = rest;
+    }
+    frontendStreams[streamId] = { ...stream, releases: slimReleases };
+  }
+  const frontendOutput = { ...output, streams: frontendStreams };
+  const tmpFrontend = FRONTEND_OUTPUT_FILE + ".tmp";
+  fs.writeFileSync(tmpFrontend, JSON.stringify(frontendOutput, null, 2), "utf-8");
+  fs.renameSync(tmpFrontend, FRONTEND_OUTPUT_FILE);
+  console.log(`SBOM frontend slim cache written to ${FRONTEND_OUTPUT_FILE}`);
 }
 
 if (require.main === module) {

--- a/scripts/fetch-github-sbom.js
+++ b/scripts/fetch-github-sbom.js
@@ -246,11 +246,15 @@ const ghcrTokenCache = new Map();
 /**
  * Get an anonymous GHCR bearer token for the given org/image.
  * Tokens are scoped per-repository and cached for the process lifetime
- * (tokens are typically valid for 5 minutes — sufficient for one run).
+ * Tokens are short-lived; we cache with expiry and refresh as needed.
  */
 async function getGhcrToken(org, image) {
   const key = `${org}/${image}`;
-  if (ghcrTokenCache.has(key)) return ghcrTokenCache.get(key);
+  const cached = ghcrTokenCache.get(key);
+  const nowMs = Date.now();
+  if (cached && cached.expiresAtMs > nowMs + 30 * 1000) {
+    return cached.token;
+  }
 
   const url = `https://ghcr.io/token?scope=repository:${org}/${image}:pull&service=ghcr.io`;
   let data;
@@ -263,8 +267,33 @@ async function getGhcrToken(org, image) {
   }
   const token = data?.token;
   if (!token) throw new Error(`No token in GHCR response for ${key}`);
-  ghcrTokenCache.set(key, token);
+  const expiresInSec = Number(data?.expires_in || 300);
+  ghcrTokenCache.set(key, {
+    token,
+    expiresAtMs: nowMs + expiresInSec * 1000,
+  });
   return token;
+}
+
+function invalidateGhcrToken(org, image) {
+  ghcrTokenCache.delete(`${org}/${image}`);
+}
+
+function selectAmd64DigestFromManifest(manifest, contentDigestHeader) {
+  const manifests = manifest?.manifests;
+  if (Array.isArray(manifests)) {
+    const amd64 = manifests.find(
+      (m) =>
+        m?.platform?.os === "linux" && m?.platform?.architecture === "amd64",
+    );
+    return amd64?.digest || null;
+  }
+
+  if (manifest?.schemaVersion === 2) {
+    return contentDigestHeader || null;
+  }
+
+  return null;
 }
 
 /**
@@ -277,19 +306,32 @@ async function getGhcrToken(org, image) {
  * Returns null if the amd64 entry cannot be found or the fetch fails.
  */
 async function resolveAmd64Digest(org, image, tag) {
-  const token = await getGhcrToken(org, image);
   const url = `https://ghcr.io/v2/${org}/${image}/manifests/${tag}`;
 
-  let manifest;
-  try {
-    manifest = await fetchJson(url, {
-      Authorization: `Bearer ${token}`,
-      Accept: [
-        "application/vnd.oci.image.index.v1+json",
-        "application/vnd.docker.distribution.manifest.list.v2+json",
-        "application/vnd.docker.distribution.manifest.v2+json",
-      ].join(", "),
+  const tryFetchManifest = async (token) => {
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: [
+          "application/vnd.oci.image.index.v1+json",
+          "application/vnd.docker.distribution.manifest.list.v2+json",
+          "application/vnd.docker.distribution.manifest.v2+json",
+        ].join(", "),
+      },
     });
+    return response;
+  };
+
+  let response;
+  try {
+    let token = await getGhcrToken(org, image);
+    response = await tryFetchManifest(token);
+
+    if (response.status === 401) {
+      invalidateGhcrToken(org, image);
+      token = await getGhcrToken(org, image);
+      response = await tryFetchManifest(token);
+    }
   } catch (err) {
     console.warn(
       `    resolveAmd64Digest: manifest fetch failed for ${org}/${image}:${tag} — ${err.message}`,
@@ -297,24 +339,26 @@ async function resolveAmd64Digest(org, image, tag) {
     return null;
   }
 
-  // Multi-arch image index: find the linux/amd64 child manifest
-  const manifests = manifest?.manifests;
-  if (Array.isArray(manifests)) {
-    const amd64 = manifests.find(
-      (m) =>
-        m?.platform?.os === "linux" && m?.platform?.architecture === "amd64",
-    );
-    if (amd64?.digest) return amd64.digest;
+  if (!response.ok) {
     console.warn(
-      `    resolveAmd64Digest: no linux/amd64 entry in index for ${org}/${image}:${tag}`,
+      `    resolveAmd64Digest: manifest fetch failed for ${org}/${image}:${tag} — HTTP ${response.status}`,
     );
     return null;
   }
 
-  // Single-arch manifest: the manifest itself is the amd64 digest carrier.
-  // We need the digest from the Content-Digest header; re-fetch with HEAD.
-  // Fall back to schemaVersion check — if it's a v2 manifest, use config.digest.
-  if (manifest?.config?.digest) return manifest.config.digest;
+  let manifest;
+  try {
+    manifest = await response.json();
+  } catch (err) {
+    console.warn(
+      `    resolveAmd64Digest: invalid manifest JSON for ${org}/${image}:${tag} — ${err.message}`,
+    );
+    return null;
+  }
+
+  const contentDigest = response.headers.get("docker-content-digest");
+  const digest = selectAmd64DigestFromManifest(manifest, contentDigest);
+  if (digest) return digest;
 
   console.warn(
     `    resolveAmd64Digest: cannot determine amd64 digest for ${org}/${image}:${tag}`,
@@ -978,7 +1022,16 @@ async function main() {
   console.log(`\nSBOM attestation cache written to ${OUTPUT_FILE}`);
 }
 
-main().catch((err) => {
-  console.error(err.message);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err.message);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  stripEpoch,
+  compareRpmVersions,
+  extractPackageVersions,
+  selectAmd64DigestFromManifest,
+};

--- a/scripts/fetch-github-sbom.test.js
+++ b/scripts/fetch-github-sbom.test.js
@@ -1,0 +1,51 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  selectAmd64DigestFromManifest,
+  stripEpoch,
+  compareRpmVersions,
+} = require("./fetch-github-sbom.js");
+
+test("selectAmd64DigestFromManifest picks linux/amd64 from multi-arch index", () => {
+  const manifest = {
+    manifests: [
+      {
+        digest: "sha256:arm64",
+        platform: { os: "linux", architecture: "arm64" },
+      },
+      {
+        digest: "sha256:amd64",
+        platform: { os: "linux", architecture: "amd64" },
+      },
+    ],
+  };
+
+  assert.equal(
+    selectAmd64DigestFromManifest(manifest, "sha256:index"),
+    "sha256:amd64",
+  );
+});
+
+test("selectAmd64DigestFromManifest uses content digest for single-arch manifest", () => {
+  const singleArchManifest = {
+    schemaVersion: 2,
+    config: { digest: "sha256:wrong-config-digest" },
+  };
+
+  assert.equal(
+    selectAmd64DigestFromManifest(singleArchManifest, "sha256:manifest-digest"),
+    "sha256:manifest-digest",
+  );
+});
+
+test("stripEpoch removes rpm epoch prefix", () => {
+  assert.equal(stripEpoch("1:25.3.6-6.fc43"), "25.3.6-6.fc43");
+  assert.equal(stripEpoch("25.3.6-6.fc43"), "25.3.6-6.fc43");
+});
+
+test("compareRpmVersions compares numeric segments correctly", () => {
+  assert.ok(compareRpmVersions("6.18.2-200", "6.18.13-200") < 0);
+  assert.ok(compareRpmVersions("6.18.13-200", "6.18.2-200") > 0);
+  assert.equal(compareRpmVersions("6.18.13-200", "6.18.13-200"), 0);
+});

--- a/src/components/FeedItems.tsx
+++ b/src/components/FeedItems.tsx
@@ -1,10 +1,6 @@
 import React, { useState, useCallback, useMemo } from "react";
 import useStoredFeed from "@theme/useStoredFeed";
 import styles from "./FeedItems.module.css";
-import {
-  PACKAGE_PATTERNS,
-  extractVersionChange,
-} from "../config/packageConfig";
 import githubProfilesData from "@site/static/data/github-profiles.json";
 import sbomAttestationsData from "@site/static/data/sbom-attestations.json";
 import type { SbomAttestationsData } from "../types/sbom";
@@ -469,19 +465,27 @@ const getContributorForAuthor = (
   author: string,
 ): ReleaseContributor | undefined => PROFILE_LOOKUP[normalizeName(author)];
 
-// Helper function to extract key version changes from changelog content
-const extractVersionSummary = (content: string): VersionChange[] => {
+const SBOM_STREAM_BY_FEED_ID: Record<string, string> = {
+  bluefinReleases: "bluefin-stable",
+  bluefinLtsReleases: "bluefin-lts",
+};
+
+const extractVersionSummary = (title: string, feedId: string): VersionChange[] => {
+  const streamId = SBOM_STREAM_BY_FEED_ID[feedId];
+  const cacheKey = extractReleaseTag(title);
+  if (!streamId || !cacheKey) return [];
+
+  const cache = sbomAttestationsData as unknown as SbomAttestationsData;
+  const packages = cache?.streams?.[streamId]?.releases?.[cacheKey]?.packageVersions;
+  if (!packages) return [];
+
   const changes: VersionChange[] = [];
-
-  if (!content) return changes;
-
-  // Use centralized package configuration
-  for (const packageConfig of PACKAGE_PATTERNS) {
-    const versionChange = extractVersionChange(content, packageConfig);
-    if (versionChange) {
-      changes.push(versionChange);
-    }
-  }
+  if (packages.kernel) changes.push({ name: "Kernel", change: packages.kernel });
+  if (packages.gnome) changes.push({ name: "GNOME", change: packages.gnome });
+  if (packages.mesa) changes.push({ name: "Mesa", change: packages.mesa });
+  if (packages.podman) changes.push({ name: "Podman", change: packages.podman });
+  if (packages.systemd) changes.push({ name: "systemd", change: packages.systemd });
+  if (packages.bootc) changes.push({ name: "bootc", change: packages.bootc });
 
   return changes;
 };
@@ -616,8 +620,8 @@ const FeedItems: React.FC<FeedItemsProps> = ({
                 : item.content);
             const itemId = item.guid || item.id || itemLink || index;
             const versionSummary =
-              isReleaseFeed(feedId) && itemDescription
-                ? extractVersionSummary(itemDescription)
+              isReleaseFeed(feedId)
+                ? extractVersionSummary(item.title, feedId)
                 : [];
             const displayTitle = formatReleaseTitle(item.title, feedId);
 

--- a/src/components/FeedItems.tsx
+++ b/src/components/FeedItems.tsx
@@ -2,7 +2,7 @@ import React, { useState, useCallback, useMemo } from "react";
 import useStoredFeed from "@theme/useStoredFeed";
 import styles from "./FeedItems.module.css";
 import githubProfilesData from "@site/static/data/github-profiles.json";
-import sbomAttestationsData from "@site/static/data/sbom-attestations.json";
+import sbomAttestationsData from "@site/static/data/sbom-attestations-frontend.json";
 import type { SbomAttestationsData } from "../types/sbom";
 
 // Small inline copy button — renders a clipboard icon, shows a tick for 1.5s after copy
@@ -306,13 +306,18 @@ const extractReleaseTag = (title: string): string | null => {
   const tagMatch = title.match(
     /(stable-\d{8}|beta-\d{8}|latest-\d{8}|lts[-.]\d{8})/i,
   );
-  if (!tagMatch) return null;
+  if (tagMatch) {
+    // Normalise lts.YYYYMMDD → lts-YYYYMMDD to match cache key format
+    return tagMatch[1]
+      .toLowerCase()
+      .replace(/^lts\.(\d{8})$/, "lts-$1");
+  }
 
-  // Normalise lts.YYYYMMDD → lts-YYYYMMDD to match cache key format
-  const normalized = tagMatch[1]
-    .toLowerCase()
-    .replace(/^lts\.(\d{8})$/, "lts-$1");
-  return normalized;
+  // LTS feed titles use "bluefin-lts LTS: YYYYMMDD (...)" format — extract date
+  const ltsDateMatch = title.match(/\bLTS:\s*(\d{8})\b/i);
+  if (ltsDateMatch) return `lts-${ltsDateMatch[1]}`;
+
+  return null;
 };
 
 const getSupplyChainLinks = (title: string, feedId?: string): SupplyChainLinks => {

--- a/src/components/ImagesCatalog.tsx
+++ b/src/components/ImagesCatalog.tsx
@@ -5,6 +5,7 @@ import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import CodeBlock from "@theme/CodeBlock";
 import styles from "./ImagesCatalog.module.css";
+import imagesCatalogData from "@site/static/data/images.json";
 
 
 interface StreamInfo {
@@ -139,26 +140,7 @@ function formatDate(value?: string | null) {
 }
 
 export default function ImagesCatalogComponent(): React.JSX.Element {
-  const [catalog, setCatalog] = React.useState<ImagesCatalog>({ products: [] });
-
-  React.useEffect(() => {
-    let mounted = true;
-
-    fetch("/data/images.json")
-      .then((response) => (response.ok ? response.json() : null))
-      .then((data) => {
-        if (!mounted || !data || !Array.isArray(data.products)) return;
-        setCatalog(data as ImagesCatalog);
-      })
-      .catch(() => {
-        if (!mounted) return;
-        setCatalog({ products: [] });
-      });
-
-    return () => {
-      mounted = false;
-    };
-  }, []);
+  const catalog = (imagesCatalogData as ImagesCatalog) || { products: [] };
 
   const products = Array.isArray(catalog?.products) ? catalog.products : [];
   const [nvidiaModeByProduct, setNvidiaModeByProduct] = React.useState<Record<string, boolean>>(

--- a/src/components/ImagesCatalog.tsx
+++ b/src/components/ImagesCatalog.tsx
@@ -5,7 +5,6 @@ import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import CodeBlock from "@theme/CodeBlock";
 import styles from "./ImagesCatalog.module.css";
-import imagesCatalogData from "@site/static/data/images.json";
 
 
 interface StreamInfo {
@@ -140,7 +139,24 @@ function formatDate(value?: string | null) {
 }
 
 export default function ImagesCatalogComponent(): React.JSX.Element {
-  const catalog = (imagesCatalogData as ImagesCatalog) || { products: [] };
+  const [catalog, setCatalog] = React.useState<ImagesCatalog>({ products: [] });
+
+  React.useEffect(() => {
+    let mounted = true;
+    fetch("/data/images.json")
+      .then((response) => (response.ok ? response.json() : null))
+      .then((data) => {
+        if (!mounted || !data || !Array.isArray(data.products)) return;
+        setCatalog(data as ImagesCatalog);
+      })
+      .catch(() => {
+        if (!mounted) return;
+        setCatalog({ products: [] });
+      });
+    return () => {
+      mounted = false;
+    };
+  }, []);
 
   const products = Array.isArray(catalog?.products) ? catalog.products : [];
   const [nvidiaModeByProduct, setNvidiaModeByProduct] = React.useState<Record<string, boolean>>(

--- a/static/data/sbom-attestations-frontend.json
+++ b/static/data/sbom-attestations-frontend.json
@@ -1,0 +1,1 @@
+{ "generatedAt": null, "streams": {} }


### PR DESCRIPTION
## Summary
- make SBOM attestations the authoritative source for kernel/GNOME/Mesa/Fedora values used by drivers, images, and changelog version summaries
- keep NVIDIA as the explicit workaround path (release-derived) while removing release-body dependency for SBOM-backed fields
- fix SBOM digest/token correctness bugs and add focused Node tests for digest selection + SBOM stream derivation

## Why
The site had mixed provenance for critical version fields (SBOM + release-body parsing + runtime fetch asymmetry), which made correctness and auditing difficult. This change enforces single-source semantics and makes data origin deterministic.

## Validation
- `node --test scripts/fetch-github-sbom.test.js scripts/fetch-github-driver-versions.test.js` (pass)
- `npm run typecheck` (pass)
- `npm run build` (pass; pre-existing Docusaurus warnings unchanged)

## Follow-ups
- #57 tracks remaining changelog summary metrics still derived from release HTML parsing.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>