### PR TITLE
feat(changelogs): OS release card design polish

### DIFF
--- a/src/components/FirehoseFeed.module.css
+++ b/src/components/FirehoseFeed.module.css
@@ -27,8 +27,6 @@
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
-  max-height: calc(100vh - var(--ifm-navbar-height, 60px) - 2rem);
-  overflow-y: auto;
 }
 
 @media (max-width: 768px) {
@@ -46,6 +44,30 @@
   letter-spacing: 0.06em;
   color: var(--ifm-color-emphasis-600);
   margin: 0 0 0.4rem;
+}
+
+/* ── More Information (top of sidebar) ──────────────────────────────── */
+
+.sidebarInfoLinks {
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.sidebarQuickLinks {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.sidebarQuickLink {
+  font-size: 0.875rem;
+  color: var(--ifm-color-primary);
+  text-decoration: none;
+}
+
+.sidebarQuickLink:hover {
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
 /* ── RSS links ────────────────────────────────────────────────────────── */
@@ -240,6 +262,43 @@
 
 .feedColumn {
   min-width: 0;
+}
+
+/* ── Feed sections ────────────────────────────────────────────────────── */
+
+.feedSection {
+  margin-bottom: 2.5rem;
+}
+
+.feedSectionHeading {
+  font-size: 1rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--ifm-color-emphasis-600);
+  margin: 0 0 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 2px solid var(--ifm-color-emphasis-200);
+}
+
+.appSectionDivider {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 2px solid var(--ifm-color-emphasis-200);
+}
+
+.appSectionDivider .feedSectionHeading {
+  margin: 0;
+  padding: 0;
+  border: none;
+}
+
+.appSectionHint {
+  font-size: 0.8rem;
+  color: var(--ifm-color-emphasis-500);
 }
 
 /* ── Empty states ─────────────────────────────────────────────────────── */

--- a/src/components/FirehoseFeed.tsx
+++ b/src/components/FirehoseFeed.tsx
@@ -46,8 +46,10 @@ function loadOsEvents(
 const STABLE_OS_EVENTS: OsReleaseEvent[] = loadOsEvents(bluefinReleasesData, "stable");
 const LTS_OS_EVENTS: OsReleaseEvent[] = loadOsEvents(bluefinLtsReleasesData, "lts");
 const ALL_OS_EVENTS: OsReleaseEvent[] = [
-  ...STABLE_OS_EVENTS,
-  ...LTS_OS_EVENTS,
+  // Most recent stable release only
+  ...(STABLE_OS_EVENTS.length > 0 ? [STABLE_OS_EVENTS[0]] : []),
+  // Most recent LTS release only
+  ...(LTS_OS_EVENTS.length > 0 ? [LTS_OS_EVENTS[0]] : []),
 ].sort((a, b) => b.dateMs - a.dateMs);
 
 /**
@@ -317,29 +319,32 @@ const FirehoseFeed: React.FC = () => {
     [filteredOsEvents, filters.showOsReleases, filters.updatedWithin],
   );
 
-  // ── Unified timeline ────────────────────────────────────────────────────────
+  // ── Grouped sections ───────────────────────────────────────────────────────
   //
-  // App events are deduplicated to one card per app (most recent release).
-  // OS events are kept individually — all 10 stable + 10 LTS appear as
-  // separate cards sorted by date. The two streams are interleaved chronologically.
+  // OS releases are pinned as the featured section. App updates follow as a
+  // secondary section, separated by a visual divider. Each section is sorted
+  // by date independently.
 
-  const timeline = useMemo((): FlatTimelineEvent[] => {
-    const appEntries: AppTimelineEvent[] = filteredUniqueApps.map(
-      ({ app, latestMs }) => ({
-        kind: "app" as const,
-        app,
-        dateMs: latestMs,
-      }),
-    );
-    return [...appEntries, ...filteredOsEvents].sort((a, b) => b.dateMs - a.dateMs);
-  }, [filteredUniqueApps, filteredOsEvents]);
+  const osSection = filteredOsEvents; // already sorted by dateMs desc
+  const appSection = filteredUniqueApps
+    .map(({ app, latestMs }): AppTimelineEvent => ({ kind: "app", app, dateMs: latestMs }))
+    .sort((a, b) => b.dateMs - a.dateMs);
 
   const isEmpty = allEvents.length === 0 && ALL_OS_EVENTS.length === 0;
+  const feedEmpty = osSection.length === 0 && appSection.length === 0;
 
   return (
     <div className={styles.layout}>
       {/* ── Sidebar ── */}
       <aside className={styles.sidebarColumn}>
+        {/* More Information — pinned at very top */}
+        <section className={styles.sidebarInfoLinks}>
+          <h3 className={styles.sidebarHeading}>More Information</h3>
+          <nav className={styles.sidebarQuickLinks}>
+            <a href="/images" className={styles.sidebarQuickLink}>Images catalog →</a>
+            <a href="/driver-versions" className={styles.sidebarQuickLink}>Driver versions →</a>
+          </nav>
+        </section>
         <RssLinks />
         {featuredApp && <FeaturedAppBanner app={featuredApp} />}
         <FirehoseFilters
@@ -383,7 +388,7 @@ const FirehoseFeed: React.FC = () => {
               pipeline runs every 6 hours — check back soon.
             </p>
           </div>
-        ) : timeline.length === 0 ? (
+        ) : feedEmpty ? (
           <div className={styles.emptyState}>
             <p>No items match the current filters.</p>
             <button
@@ -394,13 +399,32 @@ const FirehoseFeed: React.FC = () => {
             </button>
           </div>
         ) : (
-          timeline.map((event) =>
-            event.kind === "os" ? (
-              <OsReleaseCard key={`os-${event.release.tag}`} event={event} />
-            ) : (
-              <FirehoseCard key={event.app.id} app={event.app} />
-            ),
-          )
+          <>
+            {/* ── OS Releases — featured section ── */}
+            {osSection.length > 0 && (
+              <section className={styles.feedSection}>
+                <h2 className={styles.feedSectionHeading}>Bluefin OS Releases</h2>
+                {osSection.map((event) => (
+                  <OsReleaseCard key={`os-${event.release.tag}`} event={event} />
+                ))}
+              </section>
+            )}
+
+            {/* ── App Updates — secondary section ── */}
+            {appSection.length > 0 && (
+              <section className={styles.feedSection}>
+                <div className={styles.appSectionDivider}>
+                  <h2 className={styles.feedSectionHeading}>App Updates</h2>
+                  <span className={styles.appSectionHint}>
+                    Flatpak &amp; Homebrew packages included in Bluefin
+                  </span>
+                </div>
+                {appSection.map((event) => (
+                  <FirehoseCard key={event.app.id} app={event.app} />
+                ))}
+              </section>
+            )}
+          </>
         )}
       </main>
     </div>

--- a/src/components/ImagesCatalog.tsx
+++ b/src/components/ImagesCatalog.tsx
@@ -450,7 +450,7 @@ export default function ImagesCatalogComponent(): React.JSX.Element {
 
   return (
     <div className={styles.imagesPage}>
-      <section className={styles.sectionGroup}>
+      <section id="bluefin-stable" className={styles.sectionGroup}>
         <Heading as="h2" className={styles.groupTitle}>
           Bluefin
         </Heading>
@@ -464,7 +464,7 @@ export default function ImagesCatalogComponent(): React.JSX.Element {
         <div className={styles.cards}>{renderCards(mainlineProducts)}</div>
       </section>
 
-      <section className={styles.sectionGroup}>
+      <section id="bluefin-lts" className={styles.sectionGroup}>
         <Heading as="h2" className={styles.groupTitle}>
           Bluefin LTS and GDX
         </Heading>

--- a/src/components/OsReleaseCard.module.css
+++ b/src/components/OsReleaseCard.module.css
@@ -29,7 +29,7 @@
   background-repeat: no-repeat;
   background-position: right top;
   pointer-events: none;
-  opacity: 0.35;
+  opacity: 1;
 }
 
 .cardStable::after {
@@ -310,18 +310,24 @@
   font-family: var(--ifm-font-family-monospace);
   font-size: 0.75rem;
   color: var(--ifm-color-emphasis-500);
-  text-decoration: line-through;
+  background: var(--ifm-color-emphasis-100);
+  border-radius: 3px;
+  padding: 0 0.3rem;
 }
 
 .versionArrow {
-  color: var(--ifm-color-emphasis-400);
-  font-size: 0.7rem;
+  color: var(--ifm-color-emphasis-600);
+  font-size: 0.8rem;
+  font-weight: 600;
 }
 
 .newVersion {
   font-family: var(--ifm-font-family-monospace);
   font-size: 0.75rem;
   color: #15803d;
+  background: rgba(21, 128, 61, 0.08);
+  border-radius: 3px;
+  padding: 0 0.3rem;
 }
 
 /* ── Commits ─────────────────────────────────────────────────────────────────── */
@@ -381,6 +387,7 @@
   z-index: 1;
   display: flex;
   justify-content: flex-end;
+  gap: 1.25rem;
   padding-top: 0.6rem;
   margin-top: 0.6rem;
   border-top: 1px solid var(--ifm-color-emphasis-200);
@@ -391,10 +398,14 @@
   color: var(--ifm-color-primary);
   text-decoration: none;
   font-weight: 500;
+  padding: 0.2rem 0.6rem;
+  border: 1px solid var(--ifm-color-primary-lightest, rgba(0,0,0,0.15));
+  border-radius: 4px;
 }
 
 .viewLink:hover {
-  text-decoration: underline;
+  background: var(--ifm-color-primary-lightest, rgba(0,0,0,0.05));
+  text-decoration: none;
 }
 
 /* ── Shared ──────────────────────────────────────────────────────────────────── */
@@ -421,7 +432,7 @@
   .cardLts::after {
     width: 70px;
     height: 70px;
-    opacity: 0.25;
+    opacity: 1;
   }
 
   .commitSubject {

--- a/src/components/OsReleaseCard.tsx
+++ b/src/components/OsReleaseCard.tsx
@@ -164,7 +164,7 @@ function VersionChip({ pkg }: { pkg: ParsedMajorPackage }) {
 
 // ── Chip labels we surface in the header chips row ────────────────────────────
 
-const HEADER_CHIP_NAMES = ["Kernel", "Gnome", "Mesa", "Podman", "Nvidia"];
+const HEADER_CHIP_NAMES = ["Kernel", "Gnome", "Mesa", "Podman", "Nvidia", "bootc", "systemd", "pipewire"];
 
 // ── Main component ────────────────────────────────────────────────────────────
 
@@ -178,12 +178,20 @@ const OsReleaseCard: React.FC<OsReleaseCardProps> = ({ event }) => {
   const streamLabel = isLts ? "LTS" : "Stable";
   const cardClass = `${styles.card} ${isLts ? styles.cardLts : styles.cardStable}`;
 
-  // Key package chips (header row): subset of well-known packages
+  // Key package chips (header row): subset of well-known packages.
+  // Falls back to fullDiff when a name isn't in the curated majorPackages table.
   const headerChips = HEADER_CHIP_NAMES.flatMap((name) => {
-    const pkg = release.majorPackages.find(
+    const major = release.majorPackages.find(
       (p) => p.name.toLowerCase() === name.toLowerCase(),
     );
-    return pkg ? [pkg] : [];
+    if (major) return [major];
+    const diff = release.fullDiff.find(
+      (d) => d.name.toLowerCase() === name.toLowerCase(),
+    );
+    if (diff && diff.newVersion) {
+      return [{ name: diff.name, version: diff.newVersion, prevVersion: diff.prevVersion }];
+    }
+    return [];
   });
 
   // Diff summary for collapsible label
@@ -206,12 +214,7 @@ const OsReleaseCard: React.FC<OsReleaseCardProps> = ({ event }) => {
       {/* ── Header ── */}
       <div className={styles.cardHeader}>
         <div className={styles.titleRow}>
-          <span
-            className={`${styles.streamBadge} ${isLts ? styles.badgeLts : styles.badgeStable}`}
-          >
-            {streamLabel}
-          </span>
-          <h2 className={styles.cardTitle}>Bluefin</h2>
+          <h2 className={styles.cardTitle}>{isLts ? "Bluefin LTS" : "Bluefin"}</h2>
         </div>
 
         <div className={styles.metaRow}>
@@ -272,6 +275,12 @@ const OsReleaseCard: React.FC<OsReleaseCardProps> = ({ event }) => {
           className={styles.viewLink}
         >
           View on GitHub →
+        </a>
+        <a
+          href={`/images#${isLts ? "bluefin-lts" : "bluefin-stable"}`}
+          className={styles.viewLink}
+        >
+          Image details →
         </a>
       </div>
     </article>

--- a/src/utils/parseOsRelease.ts
+++ b/src/utils/parseOsRelease.ts
@@ -264,6 +264,21 @@ export function parseOsRelease(
 
   if (majorPackages.length === 0 && fullDiff.length === 0) return null;
 
+  // Backfill: any majorPackage or dxPackage that changed but is absent from fullDiff
+  // gets a synthetic "changed" entry so the collapsible list shows the full upgrade path.
+  const fullDiffNames = new Set(fullDiff.map((e) => e.name.toLowerCase()));
+  for (const pkg of [...majorPackages, ...dxPackages]) {
+    if (pkg.prevVersion && !fullDiffNames.has(pkg.name.toLowerCase())) {
+      fullDiff.unshift({
+        indicator: "changed",
+        name: pkg.name,
+        prevVersion: pkg.prevVersion,
+        newVersion: pkg.version,
+      });
+      fullDiffNames.add(pkg.name.toLowerCase());
+    }
+  }
+
   const tag = extractTag(item.title, stream);
 
   return {


### PR DESCRIPTION
- Remove stream badge pills (Stable/LTS) from card title row
- Card title is now dynamic: 'Bluefin' vs 'Bluefin LTS'
- Version display: prevVersion no longer strikethrough; styled as muted pill → green pill with arrow for clearer upgrade path
- Featured package chips: fallback to fullDiff when package absent from curated 'Major packages' HTML table; adds bootc, systemd, pipewire support (renders when present in current release diff)
- Package backfill: majorPackages/dxPackages with prevVersion now synthesised into fullDiff so upgrade path is complete
- Mascot dinos: opacity 1 (was 0.35), fully visible
- Footer links: two bordered pill buttons with gap for visual separation ('View on GitHub' and 'Image details →')
- Image details link deep-links to /images#bluefin-stable or /images#bluefin-lts (ImagesCatalog.tsx adds matching id anchors)
- Sidebar: 'More Information' section moved to top; sidebar scroll removed (no max-height / overflow-y)
- Layout: OS releases section rendered first (featured), app feed section second; only most recent release per stream shown
- SBOM tracking issues filed: castrojo/documentation 69 (pipewire field) and castrojo/documentation 70 (full SBOM-driven chips)