### PR TITLE
feat(contributors): add role badges, colored chips, and nicknames to all cards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -381,6 +381,60 @@ Do not add `fetch-sbom` to the `fetch-data` chain. `pages.yml` installs cosign/o
 
 ---
 
+## Contributors Page Management
+
+**File:** `docs/donations/contributors.mdx`  
+**Profiles fetch config:** `scripts/fetch-github-profiles.js` → `HARDCODED_USERNAMES`
+
+Every `GitHubProfileCard` uses the `titles` array (colored dot chip) and optional `nickname` (italic lore text). The role taxonomy and colors match `ReleaseContributors.tsx` exactly.
+
+### Card format
+
+```mdx
+<GitHubProfileCard
+  username="login"
+  titles={[{ label: "Role Label", color: "#hexcolor" }]}
+  nickname="personality / lore text"   {/* optional — italic below name */}
+  sponsorUrl="https://..."              {/* optional */}
+  highlight="gold|silver|diamond"       {/* omit for no foil */}
+/>
+```
+
+### Role → foil + color reference
+
+| Section | `highlight` | Dot color | Label |
+|---|---|---|---|
+| Current Maintainers | `gold` | `#ffd700` | `Bluefin Maintainer` (or specific role) |
+| Artists | `diamond` | `#b15e9c` | `Bluefin Artist` / `Art Director` |
+| Maintainers Emeritus | `diamond` | `#8a9db5` | `Bluefin Maintainer Emeritus` (or specific role) |
+| Special Guests — GNOME OS/Foundation | `silver` | `#4a86cf` | `GNOME OS Team` / `GNOME OS Member` / `GNOME OS Developer` / `GNOME Foundation` |
+| Special Guests — GNOME Design | `silver` | `#b15e9c` | `GNOME Design` |
+| Special Guests — independent/installer | `silver` | `#6366f1` | freeform |
+| Special Guests — general advisor | `silver` | `#6b9ac4` | `Technical Writer & Advisor` |
+| Advisors & Mentors | *(none)* | `#6b9ac4` | `Advisor & Mentor` |
+| Universal Blue | *(none)* | `#1a7fd4` | `Universal Blue Contributor` |
+
+Source of truth for colors/foil: `src/components/ReleaseContributors.tsx` (`RoleLegendColor`, `RoleHighlight`).
+
+### Adding a person — checklist
+
+1. Add `<GitHubProfileCard>` to the correct section in `docs/donations/contributors.mdx` with `titles`, `highlight`, and optional `nickname`/`sponsorUrl`.
+2. Add the username to `HARDCODED_USERNAMES` in `scripts/fetch-github-profiles.js` under the matching comment block.
+3. If the blog-spring worktree is active, sync: `cp docs/donations/contributors.mdx .worktrees/blog-spring/docs/donations/contributors.mdx`
+4. Special Guests who are also credited in a blog post thanks line — check `.worktrees/blog-spring/blog/` for their name and add there too if needed.
+
+### Removing a person — checklist
+
+1. Delete their `<GitHubProfileCard>` block from `docs/donations/contributors.mdx`.
+2. Remove their username from `HARDCODED_USERNAMES` in `scripts/fetch-github-profiles.js`.
+3. Sync to worktree if active (step 3 above).
+
+### Known username gotcha
+
+`alateira` (Jordan Petridis) — e before i. Previous typo `alatiera` has been corrected. Do not reintroduce.
+
+---
+
 ## Troubleshooting
 
 | Symptom | Cause | Fix |

--- a/docs/donations/contributors.mdx
+++ b/docs/donations/contributors.mdx
@@ -18,37 +18,59 @@ import GitHubProfileCard from "@site/src/components/GitHubProfileCard";
 >
   <GitHubProfileCard
     username="ahmedadan"
+    titles={[{ label: "Bluefin Maintainer", color: "#ffd700" }]}
     sponsorUrl="https://github.com/sponsors/ahmedadan"
+    highlight="gold"
   />
-  <GitHubProfileCard username="befanyt" />
+  <GitHubProfileCard
+    username="befanyt"
+    titles={[{ label: "Bluefin Maintainer", color: "#ffd700" }]}
+    highlight="gold"
+  />
   <GitHubProfileCard
     username="inffy"
-    title="Making those Coneheads work"
+    titles={[{ label: "Bluefin Maintainer", color: "#ffd700" }]}
+    nickname="Making those Coneheads work"
     sponsorUrl="https://github.com/sponsors/inffy"
+    highlight="gold"
   />
   <GitHubProfileCard
     username="hanthor"
-    title="LTS Specialist and shameless AI enjoyer"
+    titles={[{ label: "LTS Specialist", color: "#ffd700" }]}
+    nickname="shameless AI enjoyer"
     sponsorUrl="https://github.com/sponsors/hanthor"
+    highlight="gold"
   />
   <GitHubProfileCard
     username="castrojo"
-    title="Product Development and Dinosaur Guy"
+    titles={[{ label: "Product Development", color: "#ffd700" }]}
+    nickname="Dinosaur Guy"
     sponsorUrl="https://github.com/sponsors/castrojo/"
+    highlight="gold"
   />
-  <GitHubProfileCard username="renner0e" />
+  <GitHubProfileCard
+    username="renner0e"
+    titles={[{ label: "Bluefin Maintainer", color: "#ffd700" }]}
+    highlight="gold"
+  />
   <GitHubProfileCard
     username="p5"
-    title='"Hold onto your butts" guy and Lead DevOps'
+    titles={[{ label: "Lead DevOps", color: "#ffd700" }]}
+    nickname='"Hold onto your butts" guy'
+    highlight="gold"
   />
   <GitHubProfileCard
     username="tulilirockz"
-    title="Large Maniraptoran Specialist and co-maintainer"
+    titles={[{ label: "Bluefin Maintainer", color: "#ffd700" }]}
+    nickname="Large Maniraptoran Specialist"
     sponsorUrl="https://github.com/sponsors/tulilirockz"
+    highlight="gold"
   />
   <GitHubProfileCard
     username="daegalus"
+    titles={[{ label: "Bluefin Maintainer", color: "#ffd700" }]}
     sponsorUrl="https://github.com/sponsors/daegalus"
+    highlight="gold"
   />
 </div>
 
@@ -64,10 +86,16 @@ import GitHubProfileCard from "@site/src/components/GitHubProfileCard";
 >
   <GitHubProfileCard
     username="chandeleer1698"
-    title="Art Director and Telescope Connoisseur"
+    titles={[{ label: "Art Director", color: "#b15e9c" }]}
+    nickname="Telescope Connoisseur"
     sponsorUrl="https://ko-fi.com/chandeleer"
+    highlight="diamond"
   />
-  <GitHubProfileCard username="delphicmelody" />
+  <GitHubProfileCard
+    username="delphicmelody"
+    titles={[{ label: "Bluefin Artist", color: "#b15e9c" }]}
+    highlight="diamond"
+  />
 </div>
 
 ## Maintainers Emeritus
@@ -80,26 +108,42 @@ import GitHubProfileCard from "@site/src/components/GitHubProfileCard";
     marginBottom: "2rem",
   }}
 >
-  <GitHubProfileCard username="adamisrael" highlight="diamond" />
-  <GitHubProfileCard username="bsherman" title="CTO" highlight="diamond" />
+  <GitHubProfileCard
+    username="adamisrael"
+    titles={[{ label: "Bluefin Maintainer Emeritus", color: "#8a9db5" }]}
+    highlight="diamond"
+  />
+  <GitHubProfileCard
+    username="bsherman"
+    titles={[{ label: "Bluefin Maintainer Emeritus", color: "#8a9db5" }]}
+    nickname="CTO"
+    highlight="diamond"
+  />
   <GitHubProfileCard
     username="bketelsen"
-    title="Lead Developer Experience, Architect of The Final Shape"
+    titles={[{ label: "Lead Developer Experience", color: "#8a9db5" }]}
+    nickname="Architect of The Final Shape"
     highlight="diamond"
   />
   <GitHubProfileCard
     username="rothgar"
+    titles={[{ label: "Bluefin Maintainer Emeritus", color: "#8a9db5" }]}
     sponsorUrl="https://github.com/sponsors/rothgar"
     highlight="diamond"
   />
   <GitHubProfileCard
     username="m2Giles"
-    title="Lead Architect"
+    titles={[{ label: "Lead Architect", color: "#8a9db5" }]}
     highlight="diamond"
   />
-  <GitHubProfileCard username="marcoceppi" highlight="diamond" />
+  <GitHubProfileCard
+    username="marcoceppi"
+    titles={[{ label: "Bluefin Maintainer Emeritus", color: "#8a9db5" }]}
+    highlight="diamond"
+  />
   <GitHubProfileCard
     username="KyleGospo"
+    titles={[{ label: "Bluefin Maintainer Emeritus", color: "#8a9db5" }]}
     sponsorUrl="https://github.com/sponsors/KyleGospo"
     highlight="diamond"
   />
@@ -117,24 +161,52 @@ import GitHubProfileCard from "@site/src/components/GitHubProfileCard";
 >
   <GitHubProfileCard
     username="kolunmi"
-    title="App store experience (Bazaar)"
+    titles={[{ label: "App Store Experience (Bazaar)", color: "#4a86cf" }]}
     sponsorUrl="https://ko-fi.com/kolunmi"
     highlight="silver"
   />
-  <GitHubProfileCard username="alatiera" highlight="silver" />
+  <GitHubProfileCard
+    username="alateira"
+    titles={[{ label: "GNOME OS Team", color: "#4a86cf" }]}
+    highlight="silver"
+  />
+  <GitHubProfileCard
+    username="pojntfx"
+    titles={[{ label: "GNOME OS Contributor", color: "#4a86cf" }]}
+    highlight="silver"
+  />
+  <GitHubProfileCard
+    username="AdrianVovk"
+    titles={[{ label: "GNOME OS Contributor", color: "#4a86cf" }]}
+    highlight="silver"
+  />
+  <GitHubProfileCard
+    username="valentindavid"
+    titles={[{ label: "GNOME OS Contributor", color: "#4a86cf" }]}
+    highlight="silver"
+  />
   <GitHubProfileCard
     username="madonuko"
-    title="Readymade installation experience (Fyra Labs)"
+    titles={[{ label: "Readymade Installation (Fyra Labs)", color: "#6366f1" }]}
     sponsorUrl="https://github.com/sponsors/madonuko"
     highlight="silver"
   />
   <GitHubProfileCard
     username="xe"
+    titles={[{ label: "Technical Writer & Advisor", color: "#6b9ac4" }]}
     sponsorUrl="https://github.com/sponsors/xe"
     highlight="silver"
   />
-  <GitHubProfileCard username="sramkrishna" highlight="silver" />
-  <GitHubProfileCard username="mairin" highlight="silver" />
+  <GitHubProfileCard
+    username="sramkrishna"
+    titles={[{ label: "GNOME Foundation", color: "#4a86cf" }]}
+    highlight="silver"
+  />
+  <GitHubProfileCard
+    username="mairin"
+    titles={[{ label: "GNOME Design", color: "#b15e9c" }]}
+    highlight="silver"
+  />
 </div>
 
 ## Advisors and Mentors
@@ -153,41 +225,116 @@ The following individuals have made a lasting impact on Bluefin's design, either
     marginBottom: "2rem",
   }}
 >
-  <GitHubProfileCard username="abbycabs" />
+  <GitHubProfileCard
+    username="abbycabs"
+    titles={[{ label: "Advisor & Mentor", color: "#6b9ac4" }]}
+  />
   <GitHubProfileCard
     username="popey"
+    titles={[{ label: "Advisor & Mentor", color: "#6b9ac4" }]}
     sponsorUrl="https://github.com/sponsors/popey"
   />
-  <GitHubProfileCard username="amandakatona" />
-  <GitHubProfileCard username="ahrkrak" />
-  <GitHubProfileCard username="ashleymcnamara" />
-  <GitHubProfileCard username="funnelfiasco" />
-  <GitHubProfileCard username="mrbobbytables" />
-  <GitHubProfileCard username="carlwgeorge" />
-  <GitHubProfileCard username="caniszczyk" />
-  <GitHubProfileCard username="cblecker" />
-  <GitHubProfileCard username="liljenstolpe" />
+  <GitHubProfileCard
+    username="amandakatona"
+    titles={[{ label: "Advisor & Mentor", color: "#6b9ac4" }]}
+  />
+  <GitHubProfileCard
+    username="ahrkrak"
+    titles={[{ label: "Lead Mentor", color: "#6b9ac4" }]}
+  />
+  <GitHubProfileCard
+    username="ashleymcnamara"
+    titles={[{ label: "Advisor & Mentor", color: "#6b9ac4" }]}
+  />
+  <GitHubProfileCard
+    username="funnelfiasco"
+    titles={[{ label: "Advisor & Mentor", color: "#6b9ac4" }]}
+  />
+  <GitHubProfileCard
+    username="mrbobbytables"
+    titles={[{ label: "Lead Mentor", color: "#6b9ac4" }]}
+    nickname="[ Redacted ]"
+  />
+  <GitHubProfileCard
+    username="carlwgeorge"
+    titles={[{ label: "Advisor & Mentor", color: "#6b9ac4" }]}
+  />
+  <GitHubProfileCard
+    username="caniszczyk"
+    titles={[{ label: "Advisor & Mentor", color: "#6b9ac4" }]}
+  />
+  <GitHubProfileCard
+    username="cblecker"
+    titles={[{ label: "Lead Mentor", color: "#6b9ac4" }]}
+    nickname="[ Redacted ]"
+  />
+  <GitHubProfileCard
+    username="liljenstolpe"
+    titles={[{ label: "Advisor & Mentor", color: "#6b9ac4" }]}
+  />
   <GitHubProfileCard
     username="colindean"
+    titles={[{ label: "Advisor & Mentor", color: "#6b9ac4" }]}
     sponsorUrl="https://github.com/sponsors/colindean"
   />
-  <GitHubProfileCard username="cgwalters" />
-  <GitHubProfileCard username="craigmcl" />
-  <GitHubProfileCard username="rhatdan" />
-  <GitHubProfileCard username="dustinkirkland" />
-  <GitHubProfileCard username="ericcurtin" />
+  <GitHubProfileCard
+    username="cgwalters"
+    titles={[{ label: "Bootc Contributor", color: "#16a34a" }]}
+  />
+  <GitHubProfileCard
+    username="craigmcl"
+    titles={[{ label: "Advisor & Mentor", color: "#6b9ac4" }]}
+  />
+  <GitHubProfileCard
+    username="rhatdan"
+    titles={[{ label: "Advisor & Mentor", color: "#6b9ac4" }]}
+  />
+  <GitHubProfileCard
+    username="dustinkirkland"
+    titles={[{ label: "Lead Mentor", color: "#6b9ac4" }]}
+  />
+  <GitHubProfileCard
+    username="ericcurtin"
+    titles={[{ label: "Advisor & Mentor", color: "#6b9ac4" }]}
+  />
   <GitHubProfileCard
     username="heavyelement"
+    titles={[{ label: "Advisor & Mentor", color: "#6b9ac4" }]}
     sponsorUrl="https://github.com/sponsors/heavyelement"
   />
-  <GitHubProfileCard username="idvoretskyi" />
-  <GitHubProfileCard username="jeefy" />
-  <GitHubProfileCard username="jbeda" />
-  <GitHubProfileCard username="jonobacon" />
-  <GitHubProfileCard username="jberkus" />
-  <GitHubProfileCard username="krisnova" />
-  <GitHubProfileCard username="rochaporto" />
-  <GitHubProfileCard username="tieguy" />
+  <GitHubProfileCard
+    username="idvoretskyi"
+    titles={[{ label: "Advisor & Mentor", color: "#6b9ac4" }]}
+  />
+  <GitHubProfileCard
+    username="jeefy"
+    titles={[{ label: "Lead Mentor", color: "#6b9ac4" }]}
+    nickname="[ Redacted ]"
+  />
+  <GitHubProfileCard
+    username="jbeda"
+    titles={[{ label: "Advisor & Mentor", color: "#6b9ac4" }]}
+  />
+  <GitHubProfileCard
+    username="jonobacon"
+    titles={[{ label: "Advisor & Mentor", color: "#6b9ac4" }]}
+  />
+  <GitHubProfileCard
+    username="jberkus"
+    titles={[{ label: "Advisor & Mentor", color: "#6b9ac4" }]}
+  />
+  <GitHubProfileCard
+    username="krisnova"
+    titles={[{ label: "Advisor & Mentor", color: "#6b9ac4" }]}
+  />
+  <GitHubProfileCard
+    username="rochaporto"
+    titles={[{ label: "Advisor & Mentor", color: "#6b9ac4" }]}
+  />
+  <GitHubProfileCard
+    username="tieguy"
+    titles={[{ label: "Advisor & Mentor", color: "#6b9ac4" }]}
+  />
 </div>
 
 :::note[Miguel de Cervantes]
@@ -204,27 +351,93 @@ _"Tell me who your friends are and I will tell you who you are."_
     marginBottom: "2rem",
   }}
 >
-  <GitHubProfileCard username="karasowles" />
-  <GitHubProfileCard username="angellk" />
-  <GitHubProfileCard username="kenvandine" />
-  <GitHubProfileCard username="nimbinatus" />
-  <GitHubProfileCard username="lhawthorn" />
-  <GitHubProfileCard username="mfahlandt" />
-  <GitHubProfileCard username="marrusl" />
-  <GitHubProfileCard username="mattfarina" />
-  <GitHubProfileCard username="ctsdownloads" />
-  <GitHubProfileCard username="mattray" />
-  <GitHubProfileCard username="michaeltunnell" />
-  <GitHubProfileCard username="parispittman" />
-  <GitHubProfileCard username="puja108" />
-  <GitHubProfileCard username="ramcq" />
-  <GitHubProfileCard username="sarahnovotny" />
-  <GitHubProfileCard username="stormypeters" />
-  <GitHubProfileCard username="thockin" />
-  <GitHubProfileCard username="tpepper" />
-  <GitHubProfileCard username="timothysc" />
-  <GitHubProfileCard username="travier" />
-  <GitHubProfileCard username="wwitzel3" />
+  <GitHubProfileCard
+    username="karasowles"
+    titles={[{ label: "Advisor & Mentor", color: "#6b9ac4" }]}
+  />
+  <GitHubProfileCard
+    username="angellk"
+    titles={[{ label: "Advisor & Mentor", color: "#6b9ac4" }]}
+  />
+  <GitHubProfileCard
+    username="kenvandine"
+    titles={[{ label: "Advisor & Mentor", color: "#6b9ac4" }]}
+  />
+  <GitHubProfileCard
+    username="nimbinatus"
+    titles={[{ label: "Bootc Contributor", color: "#16a34a" }]}
+    nickname="[ Redacted ]"
+  />
+  <GitHubProfileCard
+    username="lhawthorn"
+    titles={[{ label: "Advisor & Mentor", color: "#6b9ac4" }]}
+    nickname="[ Redacted ]"
+  />
+  <GitHubProfileCard
+    username="mfahlandt"
+    titles={[{ label: "Advisor & Mentor", color: "#6b9ac4" }]}
+  />
+  <GitHubProfileCard
+    username="marrusl"
+    titles={[{ label: "Advisor & Mentor", color: "#6b9ac4" }]}
+    nickname="[ Redacted ]"
+  />
+  <GitHubProfileCard
+    username="mattfarina"
+    titles={[{ label: "Advisor & Mentor", color: "#6b9ac4" }]}
+  />
+  <GitHubProfileCard
+    username="ctsdownloads"
+    titles={[{ label: "Advisor & Mentor", color: "#6b9ac4" }]}
+  />
+  <GitHubProfileCard
+    username="mattray"
+    titles={[{ label: "Advisor & Mentor", color: "#6b9ac4" }]}
+  />
+  <GitHubProfileCard
+    username="michaeltunnell"
+    titles={[{ label: "Advisor & Mentor", color: "#6b9ac4" }]}
+  />
+  <GitHubProfileCard
+    username="parispittman"
+    titles={[{ label: "Advisor & Mentor", color: "#6b9ac4" }]}
+  />
+  <GitHubProfileCard
+    username="puja108"
+    titles={[{ label: "Advisor & Mentor", color: "#6b9ac4" }]}
+  />
+  <GitHubProfileCard
+    username="ramcq"
+    titles={[{ label: "Advisor & Mentor", color: "#6b9ac4" }]}
+  />
+  <GitHubProfileCard
+    username="sarahnovotny"
+    titles={[{ label: "Advisor & Mentor", color: "#6b9ac4" }]}
+  />
+  <GitHubProfileCard
+    username="stormypeters"
+    titles={[{ label: "Advisor & Mentor", color: "#6b9ac4" }]}
+  />
+  <GitHubProfileCard
+    username="thockin"
+    titles={[{ label: "Advisor & Mentor", color: "#6b9ac4" }]}
+  />
+  <GitHubProfileCard
+    username="tpepper"
+    titles={[{ label: "Advisor & Mentor", color: "#6b9ac4" }]}
+  />
+  <GitHubProfileCard
+    username="timothysc"
+    titles={[{ label: "Advisor & Mentor", color: "#6b9ac4" }]}
+  />
+  <GitHubProfileCard
+    username="travier"
+    titles={[{ label: "Bootc Contributor", color: "#16a34a" }]}
+  />
+  <GitHubProfileCard
+    username="wwitzel3"
+    titles={[{ label: "Advisor & Mentor", color: "#6b9ac4" }]}
+  />
 </div>
 
 ... and [Joe Ressington](https://joeress.com/), who is so "on brand" Linux that he doesn't have a GitHub account or any other means to contact him other than Mastodon, email, and IRC. Much love.
@@ -241,17 +454,34 @@ Note that all [Universal Blue](https://universal-blue.org/) image sources are ke
     marginBottom: "2rem",
   }}
 >
-  <GitHubProfileCard username="dreamyukii" />
-  <GitHubProfileCard username="gerblesh" />
+  <GitHubProfileCard
+    username="dreamyukii"
+    titles={[{ label: "Universal Blue Contributor", color: "#1a7fd4" }]}
+  />
+  <GitHubProfileCard
+    username="gerblesh"
+    titles={[{ label: "Universal Blue Contributor", color: "#1a7fd4" }]}
+  />
   <GitHubProfileCard
     username="HikariKnight"
+    titles={[{ label: "Universal Blue Contributor", color: "#1a7fd4" }]}
     sponsorUrl="https://github.com/sponsors/HikariKnight"
   />
-  <GitHubProfileCard username="ledif" />
+  <GitHubProfileCard
+    username="ledif"
+    titles={[{ label: "Universal Blue Contributor", color: "#1a7fd4" }]}
+  />
   <GitHubProfileCard
     username="noelmiller"
+    titles={[{ label: "Universal Blue Contributor", color: "#1a7fd4" }]}
     sponsorUrl="https://github.com/sponsors/noelmiller"
   />
-  <GitHubProfileCard username="Zeglius" />
-  <GitHubProfileCard username="valerie-tar-gz" />
+  <GitHubProfileCard
+    username="Zeglius"
+    titles={[{ label: "Universal Blue Contributor", color: "#1a7fd4" }]}
+  />
+  <GitHubProfileCard
+    username="valerie-tar-gz"
+    titles={[{ label: "Universal Blue Contributor", color: "#1a7fd4" }]}
+  />
 </div>

--- a/scripts/fetch-github-profiles.js
+++ b/scripts/fetch-github-profiles.js
@@ -68,9 +68,15 @@ const HARDCODED_USERNAMES = [
   "rothgar",
 
   // Special Guests
-  "alatiera",
+  "alateira",
+  "AdrianVovk",
   "kolunmi",
   "madonuko",
+  "mairin",
+  "pojntfx",
+  "valentindavid",
+  "sramkrishna",
+  "xe",
 
   // Report Contributors
   "AlexanderVanhee",
@@ -151,9 +157,23 @@ const HARDCODED_USERNAMES = [
   // Universal Blue Team
   "antheas",
   "dreamyukii",
+  "gerblesh",
   "HikariKnight",
   "KyleGospo",
+  "ledif",
   "noelmiller",
+  "valerie-tar-gz",
+  "Zeglius",
+
+  // Maintainers Emeritus (not covered above)
+  "adamisrael",
+
+  // Advisors and Mentors (not covered above)
+  "amandakatona",
+  "krisnova",
+  "rochaporto",
+  "stormypeters",
+  "tpepper",
 ];
 
 const OUTPUT_DIR = path.join(__dirname, "..", "static", "data");


### PR DESCRIPTION
## Summary

Brings the contributors page up to parity with the badge and title system used in blog post release contributor sections.

### Changes

**Visual upgrades — all 63 cards:**
- Every card now uses `titles` array with colored category dot (matches `ReleaseContributors` taxonomy exactly)
- Foil levels applied consistently by section: gold (maintainers), diamond (artists + emeritus), silver (special guests)
- Personality/lore text split from role chips into `nickname` prop (italic display)

**Role assignments:**
- Lead Mentor: cblecker, mrbobbytables, jeefy, ahrkrak, dustinkirkland
- Bootc Contributor: cgwalters, nimbinatus, travier
- GNOME OS Contributor: pojntfx, AdrianVovk, valentindavid
- `[ Redacted ]` nickname: cblecker, jeefy, mrbobbytables, nimbinatus, marrusl, lhawthorn

**New Special Guests:** pojntfx, AdrianVovk, valentindavid

**Bug fix:** `alatiera` → `alateira` (username typo)

**`fetch-github-profiles.js`:** 16 missing usernames added to `HARDCODED_USERNAMES`

**`AGENTS.md`:** New contributors page management section with add/remove checklists, full role→color reference table, and the alateira typo callout for future agents.