### PR TITLE
fix(MusicPlaylist): restore card variant for music page grid

### DIFF
--- a/docs/music.md
+++ b/docs/music.md
@@ -17,16 +17,19 @@ Bluefin in 2026 focuses on upstream projects and contributor growth.
 <MusicPlaylist 
   title="Bluefin and the Syrens of Metal"
   playlistId="PLhiPP9M5fgWFa09qMHJSA7ts93UsMG82Q"
+  variant="card"
 />
 
 <MusicPlaylist 
   title="Bluefin and the Bazaar of Destiny"
   playlistId="PLhiPP9M5fgWFOhFgduxhleNTmfVSj9JmO"
+  variant="card"
 />
 
 <MusicPlaylist 
   title="Bluefin and the Lost Tribe of Contributors"
   playlistId="PLhiPP9M5fgWEuxjlfOEX3fwA-E60-E4TA"
+  variant="card"
 />
 
 </div>
@@ -40,16 +43,19 @@ Bluefin forms partnerships with other legendary projects.
 <MusicPlaylist 
   title="Bluefin and Achillobator"
   playlistId="PLhiPP9M5fgWEZbkq6ZhaHA4b4UqLwZNxt"
+  variant="card"
 />
 
 <MusicPlaylist 
   title="Bluefin and Dakota"
   playlistId="PLhiPP9M5fgWHRa6Gt0UKWGxr3F0qg9t1g"
+  variant="card"
 />
 
 <MusicPlaylist 
   title="Bluefin and the Children of Jensen"
   playlistId="PLhiPP9M5fgWH4do22wEvgnoMUQLVYRIxt"
+  variant="card"
 />
 
 </div>
@@ -63,11 +69,13 @@ Bluefin was born in 2021.
 <MusicPlaylist 
   title="Bluefin and the Birth of Universal Blue"
   playlistId="PLhiPP9M5fgWHFlG3TS27gyOCQl4Dg115W"
+  variant="card"
 />
 
 <MusicPlaylist 
   title="Bluefin finds Her Way"
   playlistId="PLhiPP9M5fgWEvnp3w66WmcgiKvStzKXl9"
+  variant="card"
 />
 
 </div>

--- a/src/components/MusicPlaylist.module.css
+++ b/src/components/MusicPlaylist.module.css
@@ -1,3 +1,137 @@
+/* ── variant="card" — square thumbnail card (music page grid) ────────── */
+
+.playlistBox {
+  background-color: var(--ifm-background-color);
+  border-radius: 8px;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  overflow: hidden;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transition: all 0.2s ease;
+}
+
+.playlistBox:hover {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  transform: translateY(-2px);
+  border-color: var(--ifm-color-primary);
+}
+
+.playlistLink {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+}
+
+.playlistBox .thumbnailWrapper {
+  position: relative;
+  width: 100%;
+  padding-bottom: 100%;
+  overflow: hidden;
+  background-color: var(--ifm-color-emphasis-200);
+  flex-shrink: unset;
+  border-radius: 0;
+}
+
+.playlistBox .thumbnail {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.2s ease;
+  border-radius: 0;
+}
+
+.playlistBox:hover .thumbnail {
+  transform: scale(1.05);
+}
+
+.playlistBox .thumbnailPlaceholder {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(
+    135deg,
+    var(--ifm-color-primary-dark) 0%,
+    var(--ifm-color-primary) 100%
+  );
+}
+
+.playIcon {
+  width: 60px;
+  height: 60px;
+  color: white;
+  opacity: 0.8;
+}
+
+.playOverlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(0, 0, 0, 0);
+  transition: background-color 0.2s ease;
+}
+
+.playlistBox:hover .playOverlay {
+  background-color: rgba(0, 0, 0, 0.3);
+}
+
+.playIconLarge {
+  width: 80px;
+  height: 80px;
+  color: white;
+  opacity: 0;
+  transform: scale(0.8);
+  transition: all 0.2s ease;
+  filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.3));
+}
+
+.playlistBox:hover .playIconLarge {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.playlistInfo {
+  padding: 1rem;
+}
+
+.playlistTitle {
+  margin: 0 0 0.5rem 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-800);
+  line-height: 1.3;
+}
+
+.titleLink {
+  color: var(--ifm-color-emphasis-800);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.titleLink:hover {
+  color: var(--ifm-color-primary);
+}
+
+.playlistDescription {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--ifm-color-emphasis-600);
+  line-height: 1.4;
+}
+
+/* ── variant="bar" — slim sticky horizontal player ────────────────────── */
+
 /* ── Now Playing bar — sticky, slim horizontal player ───────────────── */
 
 .nowPlayingBar {
@@ -114,8 +248,8 @@ a.playlistTitle:hover {
 
 .videoWrapper {
   flex-shrink: 0;
-  width: 160px;
-  aspect-ratio: 16 / 9;
+  width: 90px;
+  height: 90px;
   border-radius: 4px;
   overflow: hidden;
   background-color: var(--ifm-color-emphasis-200);

--- a/src/components/MusicPlaylist.tsx
+++ b/src/components/MusicPlaylist.tsx
@@ -5,9 +5,12 @@ interface MusicPlaylistProps {
   title: string;
   playlistId: string;
   /**
-   * When true (default) an inline YouTube embed is rendered.
-   * When false, renders a linked thumbnail + title only (suitable for email/RSS).
+   * "bar"  (default) — slim sticky horizontal player; ideal for blog posts.
+   * "card" — square thumbnail card with hover overlay; ideal for the music page grid.
+   * "text" — linked thumbnail + title only, no embed (email/RSS fallback).
    */
+  variant?: "bar" | "card" | "text";
+  /** @deprecated Use variant="text" instead. */
   embed?: boolean;
 }
 
@@ -40,8 +43,12 @@ const extractPlaylistId = (playlistIdOrUrl: string): string => {
 const MusicPlaylist: React.FC<MusicPlaylistProps> = ({
   title,
   playlistId,
+  variant,
   embed = true,
 }) => {
+  // Resolve effective variant — honour legacy embed prop
+  const effectiveVariant: "bar" | "card" | "text" =
+    variant ?? (embed === false ? "text" : "bar");
   const cleanPlaylistId = extractPlaylistId(playlistId);
   const [metadata, setMetadata] = useState<PlaylistMetadata | null>(null);
   const [imageError, setImageError] = useState(false);
@@ -103,8 +110,8 @@ const MusicPlaylist: React.FC<MusicPlaylistProps> = ({
       </div>
     );
 
-  // ── embed=false fallback (email / RSS) ──────────────────────────────────
-  if (!embed) {
+  // ── variant="text" fallback (email / RSS) ──────────────────────────────────
+  if (effectiveVariant === "text") {
     return (
       <div className={styles.nowPlayingBar}>
         <a
@@ -126,6 +133,57 @@ const MusicPlaylist: React.FC<MusicPlaylistProps> = ({
           >
             {title}
           </a>
+        </div>
+      </div>
+    );
+  }
+
+  // ── variant="card" — square thumbnail card for music page grid ────────────
+  if (effectiveVariant === "card") {
+    return (
+      <div className={styles.playlistBox}>
+        <a
+          href={playlistUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={styles.playlistLink}
+        >
+          <div className={styles.thumbnailWrapper}>
+            {thumbnailUrl && !imageError ? (
+              <img
+                src={thumbnailUrl}
+                alt={title}
+                className={styles.thumbnail}
+                onError={() => setImageError(true)}
+              />
+            ) : (
+              <div className={styles.thumbnailPlaceholder}>
+                <svg className={styles.playIcon} viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M8 5v14l11-7z" />
+                </svg>
+              </div>
+            )}
+            <div className={styles.playOverlay}>
+              <svg className={styles.playIconLarge} viewBox="0 0 24 24" fill="currentColor">
+                <path d="M8 5v14l11-7z" />
+              </svg>
+            </div>
+          </div>
+        </a>
+        <div className={styles.playlistInfo}>
+          <h4 className={styles.playlistTitle}>
+            <a
+              href={playlistUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles.titleLink}
+            >
+              {title}
+            </a>
+          </h4>
+          {metadata?.description && (
+            <p className={styles.playlistDescription}>{metadata.description}</p>
+          )}
         </div>
       </div>
     );


### PR DESCRIPTION
## Problem

The sticky bar design introduced for blog posts regressed the music page — all 8 playlists were rendering as horizontal sticky bars stacked in a grid instead of the original square thumbnail cards.

## Fix

- Adds a `variant` prop: `'bar'` (default) | `'card'` | `'text'`
- Restores original card CSS: square 1:1 thumbnail, hover scale + overlay, title/description below
- Updates `docs/music.md` to pass `variant="card"` on all 8 `MusicPlaylist` instances
- Blog posts are unaffected — no `variant` prop = default `'bar'` sticky player
- Backward-compatible: legacy `embed={false}` prop still works via `effectiveVariant`